### PR TITLE
Fixing syntax error when doing text search

### DIFF
--- a/retrieval/retrieve.py
+++ b/retrieval/retrieve.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from collections import OrderedDict
 from typing import List
@@ -139,6 +140,8 @@ class CustomRetriever(BaseRetriever):
     def search_loop(table: LanceTable, query: str, vector_: List[float], limit: int) -> List[Chunk]:
         """Search LanceDB table, omit duplicate chunks, repeat the action until there are limit unique chunks (synchronous)"""
         iteration_required = True
+        # Leave only alphanumeric characters in the query using regex
+        query = re.sub(r"[^a-zA-Z0-9 ]", "", query)
         while iteration_required:  # iteration only necessary if there are duplicates (which there shouldn't be)
             chunks = table.search(query_type="hybrid").vector(vector_).text(query).limit(limit).to_pydantic(Chunk)
             found_limit_chunks = len(chunks) == limit


### PR DESCRIPTION
Hi @helenCNode, I was running into Syntax Errors when trying out the demo, and looks like this is fixing it.

I think the errors were due to using ChatGPT generations for lancedb text search, which can sometimes have special characters (I guess you're using the ChatGPT message to do another search after the initial one?)

So, this does as simple processing of the text query.