### PR TITLE
Pre langgraph refactor

### DIFF
--- a/app.py
+++ b/app.py
@@ -175,7 +175,6 @@ class Response:
             not_cited = [reference.as_html(reset_index=True) for reference in self.uncited_references]
             actual_references = "<br><br><em>Cited references:</em><br>" + "<br>".join(cited) if cited else ""
             the_rest = (
-                # Quick fix to show "May be useful" for uncited references in all situations
                 f"<br><em>{'May be useful' if cited else 'May be useful'}:</em><br>" + "<br>".join(not_cited)
                 if not_cited
                 else ""
@@ -245,13 +244,13 @@ def chat_history(*args) -> List[BaseMessage]:
     if (
         "messages" in st.session_state
     ):  # also necessary if using chat_history as an argument in rag_chain_with_citation_tool to avoid an error
-        return [message_class(message)(content=msg["content"]) for msg in st.session_state.messages[1:]]
+        return [message_class(msg)(content=msg["content"]) for msg in st.session_state.messages[1:]]
     else:
         return []
 
 
 def trace_metadata() -> Dict:
-    """Compile trace metadata on sidebar parameters and the resulting filter_condition string"""
+    """Compile trace metadata on sidebar parameters and the resulting filter_condition string, as well as settings"""
     sidebar_metadata = {key: st.session_state[key] for key in WIDGET_DEFAULTS.keys()}
     metadata = {"sidebar": sidebar_metadata}
     metadata["retriever_filter_condition"] = st.session_state["filter_condition"]
@@ -354,18 +353,21 @@ def push_feedback_to_langfuse(feedback: Dict) -> None:
 
 if __name__ == "__main__":
 
+    # settings
+    # retrieval settings
+    merge = True  # merge needs to be True from now own for indexed references and inline citations to work
+    # - otherwise we could get the same source reference appearing more than once in the reference list
+    limit = 10
+    use_tool_for_citations = False
+    split_references = True  # if True, references will be split into cited and uncited retrieved sources
+    # and the numbering reset so that references are numbered in the order they appear in the final list
+
+    # UI settings
+    initial_message = "Hi, how can I help?"
+
     if check_password():
         load_dotenv()
         logging.getLogger("httpx").setLevel(logging.WARNING)
-
-        # settings
-        # retrieval settings
-        merge = True  # merge needs to be True from now own for indexed references and inline citations to work
-        # - otherwise we could get the same source reference appearing more than once in the reference list
-        limit = 10
-        use_tool_for_citations = False
-        split_references = True  # if True, references will be split into cited and uncited retrieved sources
-        # and the numbering reset so that references are numbered in the order they appear in the final list
 
         llm = ChatOpenAI(
             temperature=0, openai_api_key=os.getenv("OPENAI_API_KEY"), model_name="gpt-4o-mini", streaming=True
@@ -470,7 +472,7 @@ if __name__ == "__main__":
         # Store session variables
         if "messages" not in st.session_state.keys():
             st.session_state.messages = [
-                {"role": "assistant", "content": "Hi, how can I help?"},
+                {"role": "assistant", "content": initial_message},
             ]
 
         # Display chat messages

--- a/app.py
+++ b/app.py
@@ -1,8 +1,6 @@
-import asyncio
 import logging
 import os
 import re
-import sys
 import uuid
 
 from datetime import datetime
@@ -11,6 +9,11 @@ from typing import List
 from typing import Optional
 from typing import Union
 
+import lxml.html  # nosec
+import streamlit as st
+
+from dotenv import load_dotenv
+from dsp_nesta_brain import logger
 from langchain.chains import create_history_aware_retriever
 from langchain.chains import create_retrieval_chain
 from langchain.chains.combine_documents import create_stuff_documents_chain
@@ -19,31 +22,16 @@ from langchain_core.messages import AIMessage
 from langchain_core.messages import BaseMessage
 from langchain_core.messages import HumanMessage
 from langchain_core.runnables.base import Runnable
+from langchain_openai import ChatOpenAI
 from langfuse import Langfuse
 from langfuse.callback import CallbackHandler
+from llm.prompt import basic_question_prompt
+from llm.prompt import contextualize_q_prompt
+from llm.prompt import qa_prompt
 from llm.tool import rag_chain_with_citation_tool
-
-
-if (
-    "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages" in sys.path
-):  # streamlit seems to not like poetry; I had to add these three lines to get it to work
-    sys.path.remove("/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages")
-sys.path.append(
-    "/Users/helen/Library/Caches/pypoetry/virtualenvs/dsp-nesta-brain-2RPY-0NE-py3.11/lib/python3.11/site-packages/"
-)
-import lxml.html  # noqa # nosec
-import streamlit as st  # noqa
-
-from dotenv import load_dotenv  # noqa
-from dsp_nesta_brain import logger  # noqa
-from langchain.chains import LLMChain  # noqa
-from langchain_openai import ChatOpenAI  # noqa
-from llm.prompt import basic_question_prompt  # noqa
-from llm.prompt import contextualize_q_prompt  # noqa
-from llm.prompt import qa_prompt  # noqa
-from retrieval.retrieve import CustomRetriever  # noqa
-from streamlit.delta_generator import DeltaGenerator  # noqa
-from streamlit_feedback import streamlit_feedback  # noqa
+from retrieval.retrieve import CustomRetriever
+from streamlit.delta_generator import DeltaGenerator
+from streamlit_feedback import streamlit_feedback
 
 
 langfuse = Langfuse()
@@ -132,47 +120,30 @@ class Reference:
 
 
 class Response:
-    """A class just to make things like printing and writing to streamlit easier"""
+    """A class just to make things like printing and writing responses to streamlit easier"""
 
     text: str
-    quoted_answer: Optional[Dict] = None  # store quoted_answer instance if a tool has been used to derived citations
-    mode: str
     references: List[Reference]
-    index: Optional[int] = None
     trace_id: Optional[str] = None  # may need trace ids to push feedback to Langfuse
 
-    def __init__(
-        self,
-        chain_response: Union[str, Dict],
-        chunks: Union[LangchainDocument, List[LangchainDocument]],
-        mode: str,
-        index: Optional[int] = None,
-    ) -> None:
+    def __init__(self, chain_response: Union[str, Dict]) -> None:
 
-        if mode == "chat":
-            if type(chain_response["answer"]) is str:
-                self.text = chain_response["answer"]
-            elif isinstance(
-                chain_response["answer"], dict
-            ):  # this will be the case if a tool has been used for citations:
-                # see quoted_answer class in llm/tool.py
-                # use isinstance, not type
-                self.quoted_answer = chain_response["answer"]["quoted_answer"]
-                self.text = self.quoted_answer["answer"]
-            chunks = chain_response["context"]
-        elif mode == "indiv":
-            self.text = chain_response.replace("ANSWER: ", "")
-            if isinstance(chunks, LangchainDocument):
-                chunks = [chunks]
+        if type(chain_response["answer"]) is str:
+            self.text = chain_response["answer"]
+        elif isinstance(
+            chain_response["answer"], dict
+        ):  # this will be the case if a tool has been used for citations:
+            # see quoted_answer class in llm/tool.py
+            # use isinstance, not type
+            self.text = chain_response["answer"]["quoted_answer"]
+        chunks = chain_response["context"]
+
         self.references = [Reference(chunk, i + 1) for i, chunk in enumerate(chunks)]
-        self.index = index
-        self.mode = mode
 
     def __repr__(self) -> str:
         """Self-explanatory"""
         string = "\n--------------\n" + self.text
-        if not self.is_summary:
-            string += f'\n{self.references[0].chunk.page_content}\n{self.references[0].metadata["location"]}'
+        string += f'\n{self.references[0].chunk.page_content}\n{self.references[0].metadata["location"]}'
         string += "\n--------------\n\n"
         return string
 
@@ -183,7 +154,7 @@ class Response:
 
     @property
     def citations_in_text(self) -> List[str]:
-        """Return the list of citations in the text, i.e. numbers appearing in square brackets"""
+        """Return the set of citations in the text, i.e. numbers appearing in square brackets"""
         return set(re.findall(r"\[\d+\]", self.text))
 
     @property
@@ -194,13 +165,7 @@ class Response:
     @property
     def p_element(self) -> str:
         """Return response text as an HTML paragraph"""
-        header = "<b>SUMMARY:</b> " if self.is_summary else (f"({self.index}) " if self.index else "")
-        return f"<p>{header}{self.text_with_superscript_citations}</p>"
-
-    @property
-    def is_summary(self) -> bool:
-        """Determine whether the response should be treated as a summary of other visible responses"""
-        return self.mode == "indiv" and self.index is None
+        return f"<p>{self.text_with_superscript_citations}</p>"
 
     @property
     def references_(self) -> str:
@@ -254,8 +219,7 @@ class Response:
 
     def as_html(self) -> str:
         """Convert the response into HTML"""
-        css_class = "response " + ("summary" if self.is_summary else "indiv")
-        return f'<div class="{css_class}">{self.p_element}{self.references_}</div>'
+        return f'<div class="response">{self.p_element}{self.references_}</div>'
 
     def reset_reference_indices(self) -> None:
         """Reset how the reference numbering will appear if references are split into cited and uncited sources"""
@@ -295,24 +259,19 @@ def trace_metadata() -> Dict:
         "merge": merge,
         "use_tool_for_citations": use_tool_for_citations,
         "limit": limit,
-        "mode": mode,
     }
     return metadata
 
 
 def llm_response(
-    chain: LLMChain,
-    docs: List[LangchainDocument],
+    chain: Runnable,
     question: str,
-    mode: str,
     message_placeholder: DeltaGenerator,
     **kwargs,
 ) -> str:
     """Get synchronous LLM response from chain"""
-    if mode == "chat":
-        input = {"input": question, "chat_history": chat_history()}
-    else:
-        input = {"context": docs, "question": question}
+
+    input = {"input": question, "chat_history": chat_history()}
     trace_id = str(uuid.uuid4())
     response = {"answer": ""}
 
@@ -332,28 +291,9 @@ def llm_response(
     return response, trace_id
 
 
-async def async_llm_response(chain: LLMChain, docs: List[LangchainDocument], question: str, **kwargs) -> str:
-    """Get asynchronous LLM response from chain"""
-    # NB: Async streaming is not implemented for now
-    input = {"context": docs, "question": question}
-    trace_id = str(uuid.uuid4())
-    response = await chain.ainvoke(input, config={"run_id": trace_id, "callbacks": [langfuse_handler]}, **kwargs)
-    langfuse.trace(id=trace_id, metadata=trace_metadata())
-    return response, trace_id
-
-
-async def individual_responses(chain: LLMChain, docs: List[LangchainDocument], question: str, **kwargs) -> List[str]:
-    """Get asynchronous LLM responses for a number of documents/chunks from chain"""
-    tasks = [asyncio.create_task(async_llm_response(chain, [doc], question, **kwargs)) for doc in docs]
-    responses_and_trace_ids = await asyncio.gather(*tasks)
-    return responses_and_trace_ids
-
-
 def respond(
     chain: Runnable,
-    docs: List[LangchainDocument],
     question: str,
-    mode: str,
     message_placeholder: DeltaGenerator,
     **kwargs,
 ) -> List[Response]:
@@ -361,22 +301,11 @@ def respond(
 
     responses = []
 
-    if mode == "indiv":
-
-        responses_and_trace_ids = asyncio.run(individual_responses(chain, docs, question, **kwargs))
-        responses_ = [
-            (response, docs[i]) for i, (response, _) in enumerate(responses_and_trace_ids) if response != "NULL"
-        ]
-        responses += [Response(response, doc, mode, index=i + 1) for i, (response, doc) in enumerate(responses_)]
-
-    chain_response, trace_id = llm_response(chain, docs, question, mode, message_placeholder)
+    chain_response, trace_id = llm_response(chain, question, message_placeholder)
 
     if chain_response["answer"] != "NULL":
-        responses.append(Response(chain_response, docs, mode))
+        responses.append(Response(chain_response))
     st.session_state["current_trace_id"] = trace_id
-
-    # for response in enumerate(responses):
-    #    logger.info(response)
 
     return responses
 
@@ -431,20 +360,12 @@ if __name__ == "__main__":
 
         # settings
         # retrieval settings
-        possible_modes = ["chat", "indiv"]
-        if sys.argv[1:] and sys.argv[1] in ["chat", "indiv"]:
-            mode = sys.argv[1]
-        else:
-            mode = "chat"  # mode is either 'chat' for a chat with memeory or 'indiv' to return one response per doc
         merge = True  # merge needs to be True from now own for indexed references and inline citations to work
         # - otherwise we could get the same source reference appearing more than once in the reference list
         limit = 10
         use_tool_for_citations = False
         split_references = True  # if True, references will be split into cited and uncited retrieved sources
         # and the numbering reset so that references are numbered in the order they appear in the final list
-
-        if mode not in possible_modes:
-            raise Exception('Mode must be "chat" or "indiv"')
 
         llm = ChatOpenAI(
             temperature=0, openai_api_key=os.getenv("OPENAI_API_KEY"), model_name="gpt-4o-mini", streaming=True
@@ -476,18 +397,7 @@ if __name__ == "__main__":
 
             .response {
                 margin: 25px 0 0 0;
-            }
-
-            .indiv {
                 background-color: light-grey;
-            }
-
-            .summary {
-                border-style: solid;
-                border-width: 1px;
-                border-radius: 5px;
-                background-color: #fae5af;
-                border-color: #fae5af;
             }
 
         </style>
@@ -496,7 +406,6 @@ if __name__ == "__main__":
         )
 
         st.markdown(
-            # f"<h2>Demo (mode = '{mode}')</h2>",
             """
             <h2>🧠 Nesta Brain</h2><br/>
             This is a prototype AI chatbot designed to help you explore Nesta's knowledge.
@@ -590,18 +499,7 @@ if __name__ == "__main__":
                 # are not passed on to the retriever
                 st.session_state["filter_condition"] = filter_condition
 
-                if mode == "indiv":
-                    if input:
-                        with st.spinner("Fetching documents ..."):
-                            chunks = retriever.invoke(input, limit=limit, enumerate=True)
-                else:
-                    chunks = []  # if mode == 'chat', retrieval is already part of the chain
-
-                if mode == "chat" or (mode == "indiv" and chunks):
-
-                    responses = respond(
-                        rag_chain if mode == "chat" else indiv_qa_chain, chunks, input, mode, message_placeholder
-                    )
+                responses = respond(rag_chain, input, message_placeholder)
 
                 if responses:
                     for response in responses:

--- a/app.py
+++ b/app.py
@@ -282,7 +282,7 @@ def respond(
     trace_id = str(uuid.uuid4())
     response = {"answer": ""}
 
-    for item in chain.stream(input_, config={"run_id": trace_id, "callbacks": [langfuse_handler]}):
+    for item in chain.stream(input, config={"run_id": trace_id, "callbacks": [langfuse_handler]}):
         # Process each item
         if "answer" in item:
             if use_tool_for_citations:

--- a/app.py
+++ b/app.py
@@ -42,7 +42,7 @@ langfuse_handler = CallbackHandler(
     secret_key=os.getenv("LANGFUSE_SECRET_KEY"),
     public_key=os.getenv("LANGFUSE_PUBLIC_KEY"),
     host=os.getenv("LANGFUSE_HOST"),
-    user_id="anon",
+    user_id=os.getenv("LANGFUSE_USER_ID"),
 )
 
 

--- a/app.py
+++ b/app.py
@@ -34,8 +34,6 @@ from streamlit.delta_generator import DeltaGenerator
 from streamlit_feedback import streamlit_feedback
 
 
-input_ = input  # only needed for testing
-
 langfuse = Langfuse()
 
 langfuse_handler = CallbackHandler(

--- a/app.py
+++ b/app.py
@@ -9,7 +9,6 @@ from typing import List
 from typing import Optional
 from typing import Union
 
-import lxml.html  # nosec
 import streamlit as st
 
 from dotenv import load_dotenv
@@ -25,7 +24,6 @@ from langchain_core.runnables.base import Runnable
 from langchain_openai import ChatOpenAI
 from langfuse import Langfuse
 from langfuse.callback import CallbackHandler
-from llm.prompt import basic_question_prompt
 from llm.prompt import contextualize_q_prompt
 from llm.prompt import qa_prompt
 from llm.tool import rag_chain_with_citation_tool
@@ -126,7 +124,7 @@ class Response:
     references: List[Reference]
     trace_id: Optional[str] = None  # may need trace ids to push feedback to Langfuse
 
-    def __init__(self, chain_response: Union[str, Dict]) -> None:
+    def __init__(self, chain_response: Dict) -> None:
 
         if type(chain_response["answer"]) is str:
             self.text = chain_response["answer"]
@@ -262,13 +260,13 @@ def trace_metadata() -> Dict:
     return metadata
 
 
-def llm_response(
+def respond(
     chain: Runnable,
     question: str,
     message_placeholder: DeltaGenerator,
     **kwargs,
-) -> str:
-    """Get synchronous LLM response from chain"""
+) -> Response:
+    """Get synchronous LLM response from chain and convert it into a Response object"""
 
     input = {"input": question, "chat_history": chat_history()}
     trace_id = str(uuid.uuid4())
@@ -277,8 +275,21 @@ def llm_response(
     for item in chain.stream(input, config={"run_id": trace_id, "callbacks": [langfuse_handler]}):
         # Process each item
         if "answer" in item:
-            response_text = item["answer"]
-            response["answer"] += str(response_text)
+            if use_tool_for_citations:
+                response_text = (
+                    item["answer"]["quoted_answer"].get("answer") or ""
+                )  # if using tool the answer will be a dict rather than string
+                if response_text and response["answer"] == response_text:
+                    break  # Once the response has been generated it will go on to the other components
+                    # of quoted_answer which we don't actually need, so stop when the answer is complete
+                response["answer"] += response_text[
+                    len(response["answer"]) :
+                ]  # unlike normal streaming, response_text contains the *cumulative* response
+                # this simulates normal streaming
+                # we could set response["answer"] = response_text, but I found this made the streaming look jerky
+            else:
+                response_text = item["answer"]
+                response["answer"] += str(response_text)
             # Display the response
             message_placeholder.markdown(response["answer"] + "▌")
         elif "context" in item:
@@ -287,29 +298,8 @@ def llm_response(
     # it will be rendered in a nicer format with references
     message_placeholder.markdown("")
     langfuse.trace(id=trace_id, metadata=trace_metadata())
-    return response, trace_id
-
-
-def respond(
-    chain: Runnable,
-    question: str,
-    message_placeholder: DeltaGenerator,
-    **kwargs,
-) -> List[Response]:
-    """Get individual and/or summary responses from chain and convert them into Response objects"""
-
-    chain_response, trace_id = llm_response(chain, question, message_placeholder)
-
-    response = Response(chain_response)
     st.session_state["current_trace_id"] = trace_id
-
-    return response
-
-
-def is_html(string: str) -> bool:
-    """Test whether a string is HTML"""
-    # credit: https://stackoverflow.com/questions/24856035/how-to-detect-with-python-if-the-string-contains-html-code
-    return lxml.html.fromstring(string).find(".//*") is not None
+    return Response(response)
 
 
 def filter_conditions() -> Union[str, None]:
@@ -352,15 +342,15 @@ if __name__ == "__main__":
 
     # settings
     # retrieval settings
-    merge = True  # merge needs to be True from now own for indexed references and inline citations to work
+    merge: bool = True  # merge needs to be True from now on for indexed references and inline citations to work
     # - otherwise we could get the same source reference appearing more than once in the reference list
-    limit = 10
-    use_tool_for_citations = False
-    split_references = True  # if True, references will be split into cited and uncited retrieved sources
+    limit: int = 10
+    use_tool_for_citations: bool = True
+    split_references: bool = True  # if True, references will be split into cited and uncited retrieved sources
     # and the numbering reset so that references are numbered in the order they appear in the final list
 
     # UI settings
-    initial_message = "Hi, how can I help?"
+    initial_message: str = "Hi, how can I help?"
 
     if check_password():
         load_dotenv()
@@ -369,17 +359,16 @@ if __name__ == "__main__":
         llm = ChatOpenAI(
             temperature=0, openai_api_key=os.getenv("OPENAI_API_KEY"), model_name="gpt-4o-mini", streaming=True
         )
-        indiv_qa_chain = create_stuff_documents_chain(llm, basic_question_prompt)
-        chat_qa_chain = create_stuff_documents_chain(llm, qa_prompt)
+
         retriever = CustomRetriever(
             merge=merge
         )  # merge cannot be passed through to the retriever via rag_chain kwargs, so set here
         # credit: https://medium.com/@eric_vaillancourt/mastering-langchain-rag-integrating-chat-history-part-2-4c80eae11b43
         history_aware_retriever = create_history_aware_retriever(llm, retriever, contextualize_q_prompt)
-
         if use_tool_for_citations:
             rag_chain = rag_chain_with_citation_tool(history_aware_retriever, llm, qa_prompt, chat_history)
         else:
+            chat_qa_chain = create_stuff_documents_chain(llm, qa_prompt)
             rag_chain = create_retrieval_chain(history_aware_retriever, chat_qa_chain)
 
         st.set_page_config(layout="wide")

--- a/app.py
+++ b/app.py
@@ -298,15 +298,12 @@ def respond(
 ) -> List[Response]:
     """Get individual and/or summary responses from chain and convert them into Response objects"""
 
-    responses = []
-
     chain_response, trace_id = llm_response(chain, question, message_placeholder)
 
-    if chain_response["answer"] != "NULL":
-        responses.append(Response(chain_response))
+    response = Response(chain_response)
     st.session_state["current_trace_id"] = trace_id
 
-    return responses
+    return response
 
 
 def is_html(string: str) -> bool:
@@ -501,16 +498,10 @@ if __name__ == "__main__":
                 # are not passed on to the retriever
                 st.session_state["filter_condition"] = filter_condition
 
-                responses = respond(rag_chain, input, message_placeholder)
-
-                if responses:
-                    for response in responses:
-                        message_placeholder.markdown(response.as_html(), unsafe_allow_html=True)
-                        message = {"role": "assistant", "html": response.as_html(), "content": response.text}
-                        st.session_state.messages.append(message)
-
-                else:
-                    st.write("I was not able to answer that question")
+                response = respond(rag_chain, input, message_placeholder)
+                message_placeholder.markdown(response.as_html(), unsafe_allow_html=True)
+                message = {"role": "assistant", "html": response.as_html(), "content": response.text}
+                st.session_state.messages.append(message)
 
         # if there is more than one response, the feedback will be pushed to Langfuse with the trace_id of the last one
         feedback = streamlit_feedback(

--- a/app.py
+++ b/app.py
@@ -13,8 +13,8 @@ import streamlit as st
 
 from dotenv import load_dotenv
 from dsp_nesta_brain import logger
-from langchain.chains import create_history_aware_retriever
-from langchain.chains import create_retrieval_chain
+
+# from langchain.chains import create_history_aware_retriever
 from langchain.chains.combine_documents import create_stuff_documents_chain
 from langchain.docstore.document import Document as LangchainDocument
 from langchain_core.messages import AIMessage
@@ -28,9 +28,13 @@ from llm.prompt import contextualize_q_prompt
 from llm.prompt import qa_prompt
 from llm.tool import rag_chain_with_citation_tool
 from retrieval.retrieve import CustomRetriever
+from retrieval.retrieve import create_history_aware_retriever
+from retrieval.retrieve import create_retrieval_chain
 from streamlit.delta_generator import DeltaGenerator
 from streamlit_feedback import streamlit_feedback
 
+
+input_ = input  # only needed for testing
 
 langfuse = Langfuse()
 
@@ -241,10 +245,13 @@ def chat_history(*args) -> List[BaseMessage]:
 
     if (
         "messages" in st.session_state
-    ):  # also necessary if using chat_history as an argument in rag_chain_with_citation_tool to avoid an error
-        return [message_class(msg)(content=msg["content"]) for msg in st.session_state.messages[1:]]
-    else:
-        return []
+    ):  # necessary if using chat_history as an argument in rag_chain_with_citation_tool to avoid an error
+        if (
+            len(st.session_state.messages) > 2
+        ):  # if the only messages are the initial_message and the first user input, then you don't need the chat history
+            return [message_class(msg)(content=msg["content"]) for msg in st.session_state.messages[1:]]
+
+    return []
 
 
 def trace_metadata() -> Dict:
@@ -268,7 +275,12 @@ def respond(
 ) -> Response:
     """Get synchronous LLM response from chain and convert it into a Response object"""
 
-    input = {"input": question, "chat_history": chat_history()}
+    input = {
+        "input": question,
+        "chat_history": chat_history(),
+        "filter_condition": st.session_state["filter_condition"],
+        "merge": merge,
+    }
     trace_id = str(uuid.uuid4())
     response = {"answer": ""}
 
@@ -360,9 +372,7 @@ if __name__ == "__main__":
             temperature=0, openai_api_key=os.getenv("OPENAI_API_KEY"), model_name="gpt-4o-mini", streaming=True
         )
 
-        retriever = CustomRetriever(
-            merge=merge
-        )  # merge cannot be passed through to the retriever via rag_chain kwargs, so set here
+        retriever = CustomRetriever()
         # credit: https://medium.com/@eric_vaillancourt/mastering-langchain-rag-integrating-chat-history-part-2-4c80eae11b43
         history_aware_retriever = create_history_aware_retriever(llm, retriever, contextualize_q_prompt)
         if use_tool_for_citations:
@@ -482,10 +492,7 @@ if __name__ == "__main__":
             with st.chat_message("assistant"):
                 message_placeholder = st.empty()
 
-                filter_condition = filter_conditions()
-                retriever.filter_condition = filter_condition  # this is not ideal syntax, but kwargs to chain.invoke
-                # are not passed on to the retriever
-                st.session_state["filter_condition"] = filter_condition
+                st.session_state["filter_condition"] = filter_conditions()
 
                 response = respond(rag_chain, input, message_placeholder)
                 message_placeholder.markdown(response.as_html(), unsafe_allow_html=True)

--- a/llm/tool.py
+++ b/llm/tool.py
@@ -1,11 +1,9 @@
 import os
 
-from operator import itemgetter
 from typing import Callable
 from typing import List
 
 from dotenv import load_dotenv  # noqa
-from dsp_nesta_brain import logger  # noqa
 from langchain.chains import LLMChain  # noqa
 from langchain.chains import create_history_aware_retriever
 from langchain.chains import create_retrieval_chain
@@ -17,7 +15,6 @@ from langchain_core.runnables import RunnableParallel
 from langchain_core.runnables import RunnablePassthrough
 from langchain_core.runnables.base import Runnable
 from langchain_openai import ChatOpenAI  # noqa
-from llm.prompt import basic_question_prompt  # noqa
 from llm.prompt import contextualize_q_prompt  # noqa
 from llm.prompt import qa_prompt  # noqa
 from pydantic import BaseModel
@@ -70,6 +67,11 @@ def rag_chain_with_citation_tool(
     retriever: BaseRetriever, llm: BaseChatModel, prompt: PromptTemplate, chat_history_func: Callable
 ) -> Runnable:
     """Return a RAG retrieval chain with incorporating a tool for capturing citations"""
+
+    # the langchain example this is based on (see https://python.langchain.com/v0.1/docs/use_cases/question_answering/citations/)
+    # uses format_docs_with_id here – this is not needed because chunk enumeration is already happening within the retriever
+    # (as long as enumerate_=True in CustomRetriever.chunks_to_docs)
+
     llm_with_tool = llm.bind_tools(
         [quoted_answer],
         tool_choice="quoted_answer",
@@ -78,14 +80,9 @@ def rag_chain_with_citation_tool(
 
     answer = prompt | llm_with_tool | output_parser
     chain = (
-        RunnableParallel(input=RunnablePassthrough(), docs={}, chat_history=chat_history_func)
-        .assign(
-            context=itemgetter("docs")
-        )  # the langchain example documentation in https://python.langchain.com/v0.1/docs/use_cases/question_answering/citations/
-        # uses format_docs_with_id here – this is not needed because chunk enumeration is already happening within the retriever
-        # (as long as enumerate_=True in CustomRetriever.chunks_to_docs)
+        RunnableParallel(input=RunnablePassthrough(), context=RunnablePassthrough(), chat_history=chat_history_func)
         .assign(quoted_answer=answer)
-        .pick(["quoted_answer", "docs"])
+        .pick(["quoted_answer"])
     )
 
     return create_retrieval_chain(retriever, chain)

--- a/llm/tool.py
+++ b/llm/tool.py
@@ -3,23 +3,25 @@ import os
 from typing import Callable
 from typing import List
 
-from dotenv import load_dotenv  # noqa
-from langchain.chains import LLMChain  # noqa
-from langchain.chains import create_history_aware_retriever
-from langchain.chains import create_retrieval_chain
+from dotenv import load_dotenv
+from langchain.chains import LLMChain
+
+# from langchain.chains import create_history_aware_retriever
 from langchain.output_parsers.openai_tools import JsonOutputKeyToolsParser
 from langchain.prompts import PromptTemplate
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.retrievers import BaseRetriever
+from langchain_core.runnables import Runnable
 from langchain_core.runnables import RunnableParallel
 from langchain_core.runnables import RunnablePassthrough
-from langchain_core.runnables.base import Runnable
-from langchain_openai import ChatOpenAI  # noqa
-from llm.prompt import contextualize_q_prompt  # noqa
-from llm.prompt import qa_prompt  # noqa
+from langchain_openai import ChatOpenAI
+from llm.prompt import contextualize_q_prompt
+from llm.prompt import qa_prompt
 from pydantic import BaseModel
 from pydantic import Field
-from retrieval.retrieve import CustomRetriever  # noqa
+from retrieval.retrieve import CustomRetriever
+from retrieval.retrieve import create_history_aware_retriever
+from retrieval.retrieve import create_retrieval_chain
 
 
 # see https://python.langchain.com/v0.1/docs/use_cases/question_answering/citations/

--- a/retrieval/retrieve.py
+++ b/retrieval/retrieve.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import os
 import re
 
 from collections import OrderedDict
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Dict
 from typing import List
 from typing import Optional
 
@@ -15,6 +20,9 @@ from lancedb.table import LanceTable
 from langchain.docstore.document import Document as LangchainDocument
 from langchain_community.vectorstores import LanceDB
 from langchain_core.retrievers import BaseRetriever
+from langchain_core.runnables import RunnableBranch
+from langchain_core.runnables import RunnableParallel
+from langchain_core.runnables import RunnablePassthrough
 from langchain_openai import OpenAIEmbeddings
 from openai import AsyncOpenAI
 from openai import OpenAI
@@ -22,39 +30,95 @@ from retrieval.db.schema import Chunk
 from utils import unique
 
 
+if TYPE_CHECKING:
+    from langchain_core.language_models import LanguageModelLike
+    from langchain_core.prompts import BasePromptTemplate
+    from langchain_core.retrievers import RetrieverLike
+    from langchain_core.retrievers import RetrieverOutputLike
+    from langchain_core.runnables import Runnable
+
 os.environ["OPENAI_API_KEY"] = os.getenv("OPENAI_API_KEY")
+
+
+def create_retrieval_chain(
+    retriever: BaseRetriever,
+    combine_docs_chain: Runnable[Dict[str, Any], str],
+) -> Runnable:
+    """
+    Create retrieval chain that retrieves documents and then passes them on.
+
+    Lightly modified version of:
+    https://github.com/langchain-ai/langchain/blob/master/libs/langchain/langchain/chains/retrieval.py
+    The modification is to allow a dict containing the query, filter conditions, and possibly other paramters to be passed through
+    to _get_relevant_documents
+    """
+
+    retrieval_chain = (
+        RunnablePassthrough.assign(
+            context=retriever.with_config(run_name="retrieve_documents"),
+        ).assign(answer=combine_docs_chain)
+    ).with_config(run_name="retrieval_chain")
+
+    return retrieval_chain
+
+
+def create_history_aware_retriever(
+    llm: LanguageModelLike,
+    retriever: RetrieverLike,
+    prompt: BasePromptTemplate,
+) -> RetrieverOutputLike:
+    """Create a chain that takes conversation history and returns documents.
+
+    Modified version of:
+    https://github.com/langchain-ai/langchain/blob/master/libs/langchain/langchain/chains/history_aware_retriever.py
+    As with create_retriever_chain, the modification is to allow a dict containing the query, filter conditions,
+    and possibly other parameters to be passed through to _get_relevant_documents
+    """
+
+    parser = lambda ai_message: ai_message.content  # noqa
+    recontextualisation_chain = prompt | llm | parser
+    recontextualisation_chain = RunnableParallel(
+        input=recontextualisation_chain,
+        filter_condition=lambda x: x.get("filter_condition"),
+        merge=lambda x: x.get("merge") or False,
+    )
+    # unlike in the original version of create_history_aware_retriever, we want filter_condition and merge
+    # to be passed through to the retriever
+
+    retrieve_documents: RetrieverOutputLike = RunnableBranch(
+        (
+            # Both empty string and empty list evaluate to False
+            lambda x: not x.get("chat_history", False),
+            # If no chat history, then we just pass input to retriever
+            retriever,
+        ),
+        # If chat history, then we pass inputs to LLM chain, then to retriever
+        recontextualisation_chain | retriever,
+    ).with_config(run_name="chat_retriever_chain")
+    return retrieve_documents
 
 
 class CustomRetriever(BaseRetriever):
     """Custom retriever class because I encountered a bug when converting a LanceDB
     vector store into a retriever in the usual way"""  # noqa
 
-    filter_condition: Optional[
-        str
-    ] = None  # added because kwargs to chain.invoke in app.py are not passed on to the retriever
-    merge: bool = False  # if True then where chunks are from the same document they will be merged into a single retrieval result
+    # async def _aget_relevant_documents(self, query: str, limit: int = 3, **kwargs) -> List[LangchainDocument]:
+    # may not be needed
+    # there have been problems getting Lance DB to work with asynchronous requests
+    #    pass
 
-    async def _aget_relevant_documents(self, query: str, limit: int = 3, **kwargs) -> List[LangchainDocument]:
-        """Retrieve chunks related to a search query using a hybrid search strategy"""
-        # doesn't currently include all the asynchronous components that if could – see async_search_loop for explanation
-        #  async_db = await lancedb.connect_async(DB_PATH)
-        db = lancedb.connect(DB_PATH)
-
-        logger.info("Vectorizing query ...")
-        vector_ = await CustomRetriever.async_vector(query)
-        #   chunks = await CustomRetriever.async_retrieve_chunks(db,query,vector_,limit)
-        chunks = CustomRetriever.retrieve_chunks(db, query, vector_, limit, **kwargs)
-        docs = CustomRetriever.chunks_to_docs(chunks, merge=self.merge, enumerate_=True)
-
-        return docs
-
-    def _get_relevant_documents(self, query: str, limit: int = 10, **kwargs) -> List[LangchainDocument]:
+    def _get_relevant_documents(self, input: Dict, limit: int = 10, **kwargs) -> List[LangchainDocument]:
         """
         Retrieve chunks related to a search query using a hybrid search strategy
 
         CAUTION: kwargs are not passed on when the retriever is part of a rag_chain and the rag_chain is invoked
+        workaround – use modified create_retrieval_chain above and pass kwarg-like arguments via an input dict (rather than str)
 
         """
+
+        query = input["input"]
+        filter_condition = input.get("filter_condition")
+        merge = input.get("merge")
 
         # the code has been chopped up into bits which can be reused easily in both synchronous and asynchronous versions
 
@@ -63,13 +127,13 @@ class CustomRetriever(BaseRetriever):
         logger.info("Vectorizing query ...")
         vector_ = CustomRetriever.vector(query)
         chunks = CustomRetriever.retrieve_chunks(
-            db, query, vector_, limit, filter_condition=self.filter_condition, **kwargs
+            db, query, vector_, limit, filter_condition=filter_condition, **kwargs
         )
         # Quick hack to give access for RAG to author and title information (by Karlis)
         for chunk in chunks:
             chunk.text = chunk.text + "; title: " + str(chunk.source.title) + "; authors: " + str(chunk.source.authors)
         # (hack ends)
-        docs = CustomRetriever.chunks_to_docs(chunks, merge=self.merge, enumerate_=True)
+        docs = CustomRetriever.chunks_to_docs(chunks, merge=merge, enumerate_=True)
 
         return docs
 


### PR DESCRIPTION
• Simplifies app.py code before deploying Langgraph
• Introduces modified versions of Langchain's create_history_aware_retriever and create_retrieval_chain so that we can pass on arguments to the retriever more easily; there is also a slight modification to CustomRetriever._get_relevant_documents
• **Note that you now need to add LANGFUSE_USER_ID = "anon" to .env**. I wanted to be able to separate out my own testing of Nesta Brain from other people's use