### PR TITLE
Langgraph extension experiment

### DIFF
--- a/app.py
+++ b/app.py
@@ -231,23 +231,14 @@ class Response:
             reference.reset_index = i + 1
 
 
-def chat_history(*args) -> List[BaseMessage]:
-    """
-    Derive chat history from streamlit messages
-
-    args are unused, but necessary if using chat_history as an argument in rag_chain_with_citation_tool to avoid an error
-    """
+def chat_history() -> List[BaseMessage]:
+    """Derive chat history from streamlit messages"""
 
     def message_class(message: Dict) -> type:
         return AIMessage if message["role"] == "assistant" else HumanMessage
 
-    if (
-        "messages" in st.session_state
-    ):  # necessary if using chat_history as an argument in rag_chain_with_citation_tool to avoid an error
-        if (
-            len(st.session_state.messages) > 2
-        ):  # if the only messages are the initial_message and the first user input, then you don't need the chat history
-            return [message_class(msg)(content=msg["content"]) for msg in st.session_state.messages[1:]]
+    if len(st.session_state.messages) > 1:  # omit initial_message from chat history
+        return [message_class(msg)(content=msg["content"]) for msg in st.session_state.messages[1:]]
 
     return []
 
@@ -280,17 +271,24 @@ def respond(
         config = {}
 
     input = {
-        "input": question,
-        "chat_history": chat_history(),
+        "messages": chat_history(),
         "filter_condition": st.session_state["filter_condition"],
         "merge": merge,
     }
 
-    response = chain.invoke(input, config=config)  # ,stream_mode="custom"):
+    if True:
+        response = chain.invoke(input, config=config)  # ,stream_mode="custom"):
+
+    else:
+        pass
+    # async for event in chain.astream_events(input, config,version="v1",stream_mode="values"):
+    # Get chat model tokens from a particular node
+    #    if event["event"] in ["on_chat_model_stream","on_chain_end"]:
+    #       print(event)
 
     if use_langfuse:
         langfuse.trace(id=trace_id, metadata=trace_metadata())
-    st.session_state["current_trace_id"] = trace_id
+        st.session_state["current_trace_id"] = trace_id
 
     return Response(response)
 
@@ -334,9 +332,9 @@ def push_feedback_to_langfuse(feedback: Dict) -> None:
 if __name__ == "__main__":
 
     # settings
-    # retrieval settings
-    use_langgraph: bool = False
     use_langfuse: bool = False
+    # retrieval settings
+    # use_langgraph: bool = False
     merge: bool = True  # merge needs to be True from now on for indexed references and inline citations to work
     # - otherwise we could get the same source reference appearing more than once in the reference list
     limit: int = 10
@@ -351,12 +349,7 @@ if __name__ == "__main__":
         load_dotenv()
         logging.getLogger("httpx").setLevel(logging.WARNING)
 
-        # if use_tool_for_citations:
-        #    rag_chain = history_aware_rag_chain_with_citation_tool(chat_history, use_langgraph=use_langgraph)
-        # else:
-        rag_chain = create_chat_graph(
-            use_langgraph=use_langgraph
-        )  # history_aware_rag_chain(use_langgraph=use_langgraph)
+        rag_chain = create_chat_graph()
 
         st.set_page_config(layout="wide")
         st.markdown(

--- a/app.py
+++ b/app.py
@@ -120,7 +120,7 @@ def respond(
     }
 
     if True:
-        response = chain.invoke(input, config=config)  # ,stream_mode="custom"):
+        final_state = chain.invoke(input, config=config)  # ,stream_mode="custom"):
 
     else:
         pass
@@ -133,7 +133,7 @@ def respond(
         langfuse.trace(id=trace_id, metadata=trace_metadata())
         st.session_state["current_trace_id"] = trace_id
 
-    return CustomAIMessage(response["response"])
+    return final_state["messages"][-1]
 
 
 def filter_conditions() -> Union[str, None]:

--- a/app.py
+++ b/app.py
@@ -2,14 +2,12 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 import uuid
 
 from datetime import datetime
 from typing import TYPE_CHECKING
 from typing import Dict
 from typing import List
-from typing import Optional
 from typing import Union
 
 import streamlit as st
@@ -18,7 +16,6 @@ from config import DEFAULT_START_YEAR
 from config import EARLIEST_YEAR
 from dotenv import load_dotenv
 from dsp_nesta_brain import logger
-from langchain.docstore.document import Document as LangchainDocument
 from langchain_core.messages import AIMessage
 from langchain_core.messages import HumanMessage
 from langchain_core.runnables.base import Runnable
@@ -28,6 +25,7 @@ from langfuse.callback import CallbackHandler
 # from llm.chain import history_aware_rag_chain
 # from llm.chain import history_aware_rag_chain_with_citation_tool
 from lgraph.graph import create_chat_graph
+from llm.message import CustomAIMessage
 from streamlit.delta_generator import DeltaGenerator
 from streamlit_feedback import streamlit_feedback
 
@@ -77,160 +75,6 @@ def check_password() -> bool:
         return True
 
 
-class Reference:
-    """A class to make inline citations easier"""
-
-    chunk: LangchainDocument
-    index: int
-    reset_index: Optional[int] = None
-    cited: bool = False
-
-    def __init__(self, chunk: LangchainDocument, index: int) -> None:
-        self.chunk = chunk
-        self.index = index
-
-    @property
-    def is_pdf(self) -> bool:
-        """Test whether the underlying source document is a PDF"""
-        return self.metadata["location"].lower()[-4:] == ".pdf"
-
-    @property
-    def metadata(self) -> Dict:
-        """Get chunk metadata"""
-        return self.chunk.metadata
-
-    def as_html(self, reset_index: bool = False) -> str:
-        """Return reference metadata as an anchor element (indexed)"""
-        test_mode = True
-        index = self.reset_index if reset_index else self.index
-        if test_mode:
-            if self.index == 1:
-                logger.warning(
-                    "Formatting of links for testing retrieval filtering is in use – do not use for production"
-                )
-            return f'<a href="{self.metadata["location"]}">[{index}] {self.metadata["title"]}{" (PDF)" if self.is_pdf else ""} {self.metadata["date_pub"]} {self.metadata["contentType"]} {self.metadata["missions"]}</a>'  # noqa
-        else:
-            return f'<a href="{self.metadata["location"]}">[{index}] {self.metadata["title"]}{" (PDF)" if self.is_pdf else ""}</a>'  # noqa
-
-    def as_superscript(self, reset_index: bool = False) -> str:
-        """Return index as a clickable link within a superscript, suitable for inline citations"""
-        return (
-            f'<sup><a href="{self.metadata["location"]}">{self.reset_index if reset_index else self.index}</a></sup>'
-        )
-
-
-class Response:
-    """A class just to make things like printing and writing responses to streamlit easier"""
-
-    text: str
-    references: List[Reference]
-    trace_id: Optional[str] = None  # may need trace ids to push feedback to Langfuse
-
-    def __init__(self, chain_response: Dict) -> None:
-
-        if type(chain_response["response"]["answer"]) is str:
-            self.text = chain_response["response"]["answer"]
-        elif isinstance(
-            chain_response["response"]["answer"], dict
-        ):  # this will be the case if a tool has been used for citations:
-            # see quoted_answer class in llm/tool.py
-            # use isinstance, not type
-            self.text = chain_response["response"]["answer"]["quoted_answer"]
-        chunks = chain_response["response"]["context"]
-
-        self.references = [Reference(chunk, i + 1) for i, chunk in enumerate(chunks)]
-
-    def __repr__(self) -> str:
-        """Self-explanatory"""
-        string = "\n--------------\n" + self.text
-        string += f'\n{self.references[0].chunk.page_content}\n{self.references[0].metadata["location"]}'
-        string += "\n--------------\n\n"
-        return string
-
-    @property
-    def a_elements(self) -> str:
-        """Return hyperlink(s) to source document(s)"""
-        return [reference.as_html() for reference in self.references]
-
-    @property
-    def citations_in_text(self) -> List[str]:
-        """Return the set of citations in the text, i.e. numbers appearing in square brackets"""
-        return set(re.findall(r"\[\d+\]", self.text))
-
-    @property
-    def cited_references(self) -> List[Reference]:
-        """Return a list of references which are actually cited in the text"""
-        return [reference for reference in self.references if reference.cited]
-
-    @property
-    def p_element(self) -> str:
-        """Return response text as an HTML paragraph"""
-        return f"<p>{self.text_with_superscript_citations}</p>"
-
-    @property
-    def references_(self) -> str:
-        """Return formatted reference list"""
-        if split_references:
-            cited = [reference.as_html(reset_index=True) for reference in self.cited_references]
-            not_cited = [reference.as_html(reset_index=True) for reference in self.uncited_references]
-            actual_references = "<br><br><em>Cited references:</em><br>" + "<br>".join(cited) if cited else ""
-            the_rest = (
-                f"<br><em>{'May be useful' if cited else 'May be useful'}:</em><br>" + "<br>".join(not_cited)
-                if not_cited
-                else ""
-            )
-            return actual_references + the_rest
-        else:
-            a_elements = [reference.as_html() for reference in self.references]
-            return "<br><br><em>Sources:</em><br>" + "<br>".join(a_elements)
-
-    @property
-    def text_with_superscript_citations(self) -> str:
-        """
-        Return text converting all citations in square brackets to a clickable superscript
-
-        Note: we may encounter problems if for some reason numbers within square brackets appear in the text
-        because they are part of the answer
-        """
-
-        if split_references:
-            self.reset_reference_indices()
-
-        text = self.text
-        N_references = len(self.references)
-        for citation in self.citations_in_text:
-            citation_index = int(citation[1:-1])  # remove the square brackets
-            if citation_index <= N_references:  # citation indices are in the range 1:N rather than 0:(N-1)
-                reference = self.references[citation_index - 1]
-                superscript = reference.as_superscript(reset_index=split_references)
-                text = text.replace(citation, superscript)
-            else:
-                logging.warning(f"Citation {citation} contained an index greater than the number of references")
-        text = text.replace(
-            "</sup><sup>", ","
-        )  # where there are citations next to each other, merge them into the same superscript and separate them with commas
-        return text
-
-    @property
-    def uncited_references(self) -> List[Reference]:
-        """Return a list of references which are not cited in the text"""
-        return [reference for reference in self.references if not reference.cited]
-
-    def as_html(self) -> str:
-        """Convert the response into HTML"""
-        return f'<div class="response">{self.p_element}{self.references_}</div>'
-
-    def reset_reference_indices(self) -> None:
-        """Reset how the reference numbering will appear if references are split into cited and uncited sources"""
-        for citation in self.citations_in_text:
-            citation_index = int(citation[1:-1])
-            reference = self.references[citation_index - 1]
-            reference.cited = True
-
-        for i, reference in enumerate(self.cited_references + self.uncited_references):
-            reference.reset_index = i + 1
-
-
 def chat_history() -> List[BaseMessage]:
     """Derive chat history from streamlit messages"""
 
@@ -258,11 +102,10 @@ def trace_metadata() -> Dict:
 
 def respond(
     chain: Runnable,
-    question: str,
     message_placeholder: DeltaGenerator,
     **kwargs,
-) -> Response:
-    """Get synchronous LLM response from chain and convert it into a Response object"""
+) -> CustomAIMessage:
+    """Get synchronous LLM response from chain and convert it into a CustomAIMessage"""
 
     if use_langfuse:
         trace_id = str(uuid.uuid4())
@@ -290,7 +133,7 @@ def respond(
         langfuse.trace(id=trace_id, metadata=trace_metadata())
         st.session_state["current_trace_id"] = trace_id
 
-    return Response(response)
+    return CustomAIMessage(response["response"])
 
 
 def filter_conditions() -> Union[str, None]:
@@ -334,13 +177,11 @@ if __name__ == "__main__":
     # settings
     use_langfuse: bool = False
     # retrieval settings
-    # use_langgraph: bool = False
+    # use_langgraph: bool = False    #for simplification
     merge: bool = True  # merge needs to be True from now on for indexed references and inline citations to work
     # - otherwise we could get the same source reference appearing more than once in the reference list
     limit: int = 10
     use_tool_for_citations: bool = False
-    split_references: bool = True  # if True, references will be split into cited and uncited retrieved sources
-    # and the numbering reset so that references are numbered in the order they appear in the final list
 
     # UI settings
     initial_message: str = "Hi, how can I help?"
@@ -464,9 +305,9 @@ if __name__ == "__main__":
 
                 st.session_state["filter_condition"] = filter_conditions()
 
-                response = respond(rag_chain, input, message_placeholder)
+                response = respond(rag_chain, message_placeholder)
                 message_placeholder.markdown(response.as_html(), unsafe_allow_html=True)
-                message = {"role": "assistant", "html": response.as_html(), "content": response.text}
+                message = {"role": "assistant", "html": response.as_html(), "content": response.content}
                 st.session_state.messages.append(message)
 
         if use_langfuse:

--- a/app.py
+++ b/app.py
@@ -101,7 +101,7 @@ class Reference:
 
     def as_html(self, reset_index: bool = False) -> str:
         """Return reference metadata as an anchor element (indexed)"""
-        test_mode = False
+        test_mode = True
         index = self.reset_index if reset_index else self.index
         if test_mode:
             if self.index == 1:
@@ -128,15 +128,15 @@ class Response:
 
     def __init__(self, chain_response: Dict) -> None:
 
-        if type(chain_response["answer"]) is str:
-            self.text = chain_response["answer"]
+        if type(chain_response["response"]["answer"]) is str:
+            self.text = chain_response["response"]["answer"]
         elif isinstance(
-            chain_response["answer"], dict
+            chain_response["response"]["answer"], dict
         ):  # this will be the case if a tool has been used for citations:
             # see quoted_answer class in llm/tool.py
             # use isinstance, not type
-            self.text = chain_response["answer"]["quoted_answer"]
-        chunks = chain_response["context"]
+            self.text = chain_response["response"]["answer"]["quoted_answer"]
+        chunks = chain_response["response"]["context"]
 
         self.references = [Reference(chunk, i + 1) for i, chunk in enumerate(chunks)]
 
@@ -273,45 +273,25 @@ def respond(
 ) -> Response:
     """Get synchronous LLM response from chain and convert it into a Response object"""
 
+    if use_langfuse:
+        trace_id = str(uuid.uuid4())
+        config = {"run_id": trace_id, "callbacks": [langfuse_handler]}
+    else:
+        config = {}
+
     input = {
         "input": question,
         "chat_history": chat_history(),
         "filter_condition": st.session_state["filter_condition"],
         "merge": merge,
     }
-    trace_id = str(uuid.uuid4())
-    response = {"answer": ""}
 
-    for item in chain.stream(
-        input, stream_mode="custom"
-    ):  # , config={"run_id": trace_id, "callbacks": [langfuse_handler]}):
+    response = chain.invoke(input, config=config)  # ,stream_mode="custom"):
 
-        # Process each item
-        if "answer" in item:
-            if use_tool_for_citations:
-                response_text = (
-                    item["answer"]["quoted_answer"].get("answer") or ""
-                )  # if using tool the answer will be a dict rather than string
-                if response_text and response["answer"] == response_text:
-                    break  # Once the response has been generated it will go on to the other components
-                    # of quoted_answer which we don't actually need, so stop when the answer is complete
-                response["answer"] += response_text[
-                    len(response["answer"]) :
-                ]  # unlike normal streaming, response_text contains the *cumulative* response
-                # this simulates normal streaming
-                # we could set response["answer"] = response_text, but I found this made the streaming look jerky
-            else:
-                response_text = item["answer"]
-                response["answer"] += str(response_text)
-            # Display the response
-            message_placeholder.markdown(response["answer"] + "▌")
-        elif "context" in item:
-            response["context"] = item["context"]
-    # Remove the message placeholder text after all the text has been received, as
-    # it will be rendered in a nicer format with references
-    message_placeholder.markdown("")
-    #  langfuse.trace(id=trace_id, metadata=trace_metadata())
+    if use_langfuse:
+        langfuse.trace(id=trace_id, metadata=trace_metadata())
     st.session_state["current_trace_id"] = trace_id
+
     return Response(response)
 
 
@@ -355,7 +335,8 @@ if __name__ == "__main__":
 
     # settings
     # retrieval settings
-    use_langgraph: bool = True
+    use_langgraph: bool = False
+    use_langfuse: bool = False
     merge: bool = True  # merge needs to be True from now on for indexed references and inline citations to work
     # - otherwise we could get the same source reference appearing more than once in the reference list
     limit: int = 10
@@ -495,10 +476,10 @@ if __name__ == "__main__":
                 message = {"role": "assistant", "html": response.as_html(), "content": response.text}
                 st.session_state.messages.append(message)
 
-        # if there is more than one response, the feedback will be pushed to Langfuse with the trace_id of the last one
-        feedback = streamlit_feedback(
-            feedback_type="faces",
-            optional_text_label="[Optional] Please provide an explanation",
-            key="feedback",
-            on_submit=push_feedback_to_langfuse,
-        )
+        if use_langfuse:
+            feedback = streamlit_feedback(
+                feedback_type="faces",
+                optional_text_label="[Optional] Please provide an explanation",
+                key="feedback",
+                on_submit=push_feedback_to_langfuse,
+            )

--- a/app.py
+++ b/app.py
@@ -123,37 +123,78 @@ def respond(
         "merge": merge,
     }
 
-    if stream:
+    if use_graph:
 
-        async def stream_() -> State:
+        if stream:
+
+            async def stream_() -> State:
+                message_text = ""
+                id = None
+                async for event in chain.astream_events(input, config, version="v1", stream_mode="values"):
+                    if event["event"] == "on_chat_model_stream":
+                        ai_message_chunk = event["data"]["chunk"]
+                        if id != ai_message_chunk.id:
+                            if id:
+                                message_text += "\n\n"
+                            id = ai_message_chunk.id
+                        message_text += ai_message_chunk.content
+                        message_placeholder.markdown(message_text + "▌")
+                    elif event["event"] == "on_chain_end" and event["name"] == "test":
+                        final_state = event["data"]["input"]
+                return final_state
+
+            final_state = asyncio.run(stream_())
+
+        else:
+            final_state = chain.invoke(input, config=config)
+
+        return_message = final_state["messages"][-1]
+
+    else:
+
+        if stream:
+
             message_text = ""
-            id = None
-            async for event in chain.astream_events(input, config, version="v1", stream_mode="values"):
-                if event["event"] == "on_chat_model_stream":
-                    ai_message_chunk = event["data"]["chunk"]
-                    if id != ai_message_chunk.id:
-                        if id:
-                            message_text += "\n\n"
-                        id = ai_message_chunk.id
-                    message_text += ai_message_chunk.content
+            for item in chain.stream(input, config=config):
+                # Process each item
+                if "answer" in item:
+                    if use_tool_for_citations:
+                        item_text = (
+                            item["answer"]["quoted_answer"].get("answer") or ""
+                        )  # if using tool the answer will be a dict rather than string
+                        if item_text and item_text == message_text:
+                            break  # Once the response has been generated it will go on to the other components
+                            # of quoted_answer which we don't actually need, so stop when the answer is complete
+                        message_text += item_text[
+                            len(message_text) :
+                        ]  # unlike normal streaming, message_text contains the *cumulative* response
+                        # this simulates normal streaming
+                        # we could set response["answer"] = message_text, but I found this made the streaming look jerky
+                    else:
+                        message_text += str(item["answer"])
+                    # Display the response
                     message_placeholder.markdown(message_text + "▌")
-                elif event["event"] == "on_chain_end" and event["name"] == "test":
-                    final_state = event["data"]["input"]
-            return final_state
 
-        final_state = asyncio.run(stream_())
+                elif "context" in item:
+                    context = item["context"]
+
+            response = {"answer": message_text, "context": context}
+
+        else:
+            response = chain.invoke(input, config=config)
+
+        return_message = CustomAIMessage(response)
+
+    if stream:
         # Remove the message placeholder text after all the text has been received, as
         # it will be rendered in a nicer format with references
         message_placeholder.markdown("")
-
-    else:
-        final_state = chain.invoke(input, config=config)
 
     if use_langfuse:
         langfuse.trace(id=trace_id, metadata=trace_metadata())
         st.session_state["current_trace_id"] = trace_id
 
-    return final_state["messages"][-1]
+    return return_message
 
 
 def filter_conditions() -> Union[str, None]:
@@ -196,7 +237,7 @@ if __name__ == "__main__":
 
     # settings
     use_graph: bool = True
-    use_langfuse: bool = True
+    use_langfuse: bool = False
     stream: bool = True
     # retrieval settings
     # use_langgraph: bool = False    #for simplification. This was previously the setting to use LangGraph for retrieval
@@ -213,7 +254,7 @@ if __name__ == "__main__":
         logging.getLogger("httpx").setLevel(logging.WARNING)
 
         if use_tool_for_citations:
-            raise Exception("use_tool_for_citations may no longer work – you need to check")
+            raise Exception("use_tool_for_citations may no longer work – need to check")
 
         if use_graph:
             rag_chain = create_chat_graph()

--- a/app.py
+++ b/app.py
@@ -237,7 +237,7 @@ if __name__ == "__main__":
 
     # settings
     use_graph: bool = True
-    use_langfuse: bool = False
+    use_langfuse: bool = True
     stream: bool = True
     # retrieval settings
     # use_langgraph: bool = False    #for simplification. This was previously the setting to use LangGraph for retrieval

--- a/app.py
+++ b/app.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import logging
 import os
 import re
 import uuid
 
 from datetime import datetime
+from typing import TYPE_CHECKING
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -17,15 +20,20 @@ from dotenv import load_dotenv
 from dsp_nesta_brain import logger
 from langchain.docstore.document import Document as LangchainDocument
 from langchain_core.messages import AIMessage
-from langchain_core.messages import BaseMessage
 from langchain_core.messages import HumanMessage
 from langchain_core.runnables.base import Runnable
 from langfuse import Langfuse
 from langfuse.callback import CallbackHandler
-from llm.chain import history_aware_rag_chain
-from llm.chain import history_aware_rag_chain_with_citation_tool
+
+# from llm.chain import history_aware_rag_chain
+# from llm.chain import history_aware_rag_chain_with_citation_tool
+from lgraph.graph import create_chat_graph
 from streamlit.delta_generator import DeltaGenerator
 from streamlit_feedback import streamlit_feedback
+
+
+if TYPE_CHECKING:
+    from langchain_core.messages import BaseMessage
 
 
 langfuse = Langfuse()
@@ -274,7 +282,10 @@ def respond(
     trace_id = str(uuid.uuid4())
     response = {"answer": ""}
 
-    for item in chain.stream(input, config={"run_id": trace_id, "callbacks": [langfuse_handler]}):
+    for item in chain.stream(
+        input, stream_mode="custom"
+    ):  # , config={"run_id": trace_id, "callbacks": [langfuse_handler]}):
+
         # Process each item
         if "answer" in item:
             if use_tool_for_citations:
@@ -299,7 +310,7 @@ def respond(
     # Remove the message placeholder text after all the text has been received, as
     # it will be rendered in a nicer format with references
     message_placeholder.markdown("")
-    langfuse.trace(id=trace_id, metadata=trace_metadata())
+    #  langfuse.trace(id=trace_id, metadata=trace_metadata())
     st.session_state["current_trace_id"] = trace_id
     return Response(response)
 
@@ -359,10 +370,12 @@ if __name__ == "__main__":
         load_dotenv()
         logging.getLogger("httpx").setLevel(logging.WARNING)
 
-        if use_tool_for_citations:
-            rag_chain = history_aware_rag_chain_with_citation_tool(chat_history, use_langgraph=use_langgraph)
-        else:
-            rag_chain = history_aware_rag_chain(use_langgraph=use_langgraph)
+        # if use_tool_for_citations:
+        #    rag_chain = history_aware_rag_chain_with_citation_tool(chat_history, use_langgraph=use_langgraph)
+        # else:
+        rag_chain = create_chat_graph(
+            use_langgraph=use_langgraph
+        )  # history_aware_rag_chain(use_langgraph=use_langgraph)
 
         st.set_page_config(layout="wide")
         st.markdown(

--- a/app.py
+++ b/app.py
@@ -22,11 +22,11 @@ from langchain_core.messages import HumanMessage
 from langchain_core.runnables.base import Runnable
 from langfuse import Langfuse
 from langfuse.callback import CallbackHandler
-
-# from llm.chain import history_aware_rag_chain
-# from llm.chain import history_aware_rag_chain_with_citation_tool
+from lgraph.graph import LAST_CHAT_GRAPH_NODE_NAME
 from lgraph.graph import create_chat_graph
 from llm.chain import history_aware_rag_chain
+
+# from llm.chain import history_aware_rag_chain_with_citation_tool
 from llm.message import CustomAIMessage
 from streamlit.delta_generator import DeltaGenerator
 from streamlit_feedback import streamlit_feedback
@@ -139,7 +139,7 @@ def respond(
                             id = ai_message_chunk.id
                         message_text += ai_message_chunk.content
                         message_placeholder.markdown(message_text + "▌")
-                    elif event["event"] == "on_chain_end" and event["name"] == "test":
+                    elif event["event"] == "on_chain_end" and event["name"] == LAST_CHAT_GRAPH_NODE_NAME:
                         final_state = event["data"]["input"]
                 return final_state
 

--- a/app.py
+++ b/app.py
@@ -26,6 +26,7 @@ from langfuse.callback import CallbackHandler
 # from llm.chain import history_aware_rag_chain
 # from llm.chain import history_aware_rag_chain_with_citation_tool
 from lgraph.graph import create_chat_graph
+from llm.chain import history_aware_rag_chain
 from llm.message import CustomAIMessage
 from streamlit.delta_generator import DeltaGenerator
 from streamlit_feedback import streamlit_feedback
@@ -97,6 +98,7 @@ def trace_metadata() -> Dict:
     metadata["settings"] = {
         "merge": merge,
         "use_tool_for_citations": use_tool_for_citations,
+        "use_graph": use_graph,
         "limit": limit,
     }
     return metadata
@@ -193,10 +195,11 @@ def push_feedback_to_langfuse(feedback: Dict) -> None:
 if __name__ == "__main__":
 
     # settings
-    use_langfuse: bool = False
+    use_graph: bool = True
+    use_langfuse: bool = True
     stream: bool = True
     # retrieval settings
-    # use_langgraph: bool = False    #for simplification
+    # use_langgraph: bool = False    #for simplification. This was previously the setting to use LangGraph for retrieval
     merge: bool = True  # merge needs to be True from now on for indexed references and inline citations to work
     # - otherwise we could get the same source reference appearing more than once in the reference list
     limit: int = 10
@@ -209,7 +212,13 @@ if __name__ == "__main__":
         load_dotenv()
         logging.getLogger("httpx").setLevel(logging.WARNING)
 
-        rag_chain = create_chat_graph()
+        if use_tool_for_citations:
+            raise Exception("use_tool_for_citations may no longer work – you need to check")
+
+        if use_graph:
+            rag_chain = create_chat_graph()
+        else:
+            rag_chain = history_aware_rag_chain()
 
         st.set_page_config(layout="wide")
         st.markdown(

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import uuid
@@ -32,6 +33,7 @@ from streamlit_feedback import streamlit_feedback
 
 if TYPE_CHECKING:
     from langchain_core.messages import BaseMessage
+    from retrieval.retrieve import RetrieverInput as State
 
 
 langfuse = Langfuse()
@@ -105,7 +107,7 @@ def respond(
     message_placeholder: DeltaGenerator,
     **kwargs,
 ) -> CustomAIMessage:
-    """Get synchronous LLM response from chain and convert it into a CustomAIMessage"""
+    """Get LLM response from chain"""
 
     if use_langfuse:
         trace_id = str(uuid.uuid4())
@@ -119,15 +121,31 @@ def respond(
         "merge": merge,
     }
 
-    if True:
-        final_state = chain.invoke(input, config=config)  # ,stream_mode="custom"):
+    if stream:
+
+        async def stream_() -> State:
+            message_text = ""
+            id = None
+            async for event in chain.astream_events(input, config, version="v1", stream_mode="values"):
+                if event["event"] == "on_chat_model_stream":
+                    ai_message_chunk = event["data"]["chunk"]
+                    if id != ai_message_chunk.id:
+                        if id:
+                            message_text += "\n\n"
+                        id = ai_message_chunk.id
+                    message_text += ai_message_chunk.content
+                    message_placeholder.markdown(message_text + "▌")
+                elif event["event"] == "on_chain_end" and event["name"] == "test":
+                    final_state = event["data"]["input"]
+            return final_state
+
+        final_state = asyncio.run(stream_())
+        # Remove the message placeholder text after all the text has been received, as
+        # it will be rendered in a nicer format with references
+        message_placeholder.markdown("")
 
     else:
-        pass
-    # async for event in chain.astream_events(input, config,version="v1",stream_mode="values"):
-    # Get chat model tokens from a particular node
-    #    if event["event"] in ["on_chat_model_stream","on_chain_end"]:
-    #       print(event)
+        final_state = chain.invoke(input, config=config)
 
     if use_langfuse:
         langfuse.trace(id=trace_id, metadata=trace_metadata())
@@ -176,6 +194,7 @@ if __name__ == "__main__":
 
     # settings
     use_langfuse: bool = False
+    stream: bool = True
     # retrieval settings
     # use_langgraph: bool = False    #for simplification
     merge: bool = True  # merge needs to be True from now on for indexed references and inline citations to work

--- a/config.py
+++ b/config.py
@@ -1,5 +1,8 @@
 # DB_PATH = "retrieval/db/ccid_demo_db"
 DB_PATH = "retrieval/db/full_site_demo_db_with_pdfs"
 DEFAULT_MODEL = "gpt-4o-mini"
+DEFAULT_EMBEDDINGS_MODEL = "text-embedding-3-small"
+RPM_RATE_LIMIT = 10000
+TPM_RATE_LIMIT = 5e6
 EARLIEST_YEAR = 2003  # 2003 is the earliest publication date in the DB
 DEFAULT_START_YEAR = 2019

--- a/eval/langfuse_ragas.py
+++ b/eval/langfuse_ragas.py
@@ -9,17 +9,14 @@ from typing import List
 from typing import Optional
 from typing import Union
 
+from config import DEFAULT_EMBEDDINGS_MODEL
 from dotenv import load_dotenv
 from dsp_nesta_brain import logger
 from langchain_openai import ChatOpenAI
 from langchain_openai import OpenAIEmbeddings
 from langfuse import Langfuse
 from langfuse.client import FetchTracesResponse
-
-# from metrics import ContextSemanticSimilarity
 from metrics import CorrectedSummarizationScore as SummarizationScore
-
-# from metrics import summarization_score
 from ragas import EvaluationDataset
 from ragas import MultiTurnSample
 from ragas import SingleTurnSample
@@ -231,7 +228,7 @@ def push_scores_to_langfuse(samples: List[BaseSample], trace_ids: List[str], met
 if __name__ == "__main__":
 
     evaluator_llm = LangchainLLMWrapper(ChatOpenAI(model="gpt-4o-mini"))
-    evaluator_embeddings = LangchainEmbeddingsWrapper(OpenAIEmbeddings(model="text-embedding-3-small"))
+    evaluator_embeddings = LangchainEmbeddingsWrapper(OpenAIEmbeddings(model=DEFAULT_EMBEDDINGS_MODEL))
 
     traces = langfuse.fetch_traces()
     samples, trace_ids = traces_to_samples(traces)

--- a/eval/langfuse_ragas.py
+++ b/eval/langfuse_ragas.py
@@ -168,40 +168,42 @@ def traces_to_samples(
     answer_history = []
     for i, trace in enumerate(traces):
 
-        is_single_turn_sample = False
+        if type(trace.output) is dict and "answer" in trace.output:  # if str it will be an error message
 
-        next_trace = traces[i + 1] if i < len(traces) - 1 else None
-        if next_trace:
-            input_appears_in_next_trace_chat_history = any(
-                message["content"] == trace.input["input"] for message in next_trace.input["chat_history"]
-            )
-        else:
-            input_appears_in_next_trace_chat_history = False
+            is_single_turn_sample = False
 
-        if input_appears_in_next_trace_chat_history:
-            # if input_appears_in_next_trace_chat_history = True, the message will eventually appear in
-            # the conversation of a MultiTurnSample, so do not instantiate a sample for it
-            # but do retain the answer history for when the MultiTurnSample is eventually instantiated
-            answer_history.append(trace.output["answer"])
-        else:
-            # trace is either a SingleTurnSample or the last trace defining a MultiTurnSample
-            is_single_turn_sample = len(trace.input["chat_history"]) == 1
-
-            if is_single_turn_sample:
-                sample = SingleTurnSample(
-                    user_input=trace.input["input"],
-                    retrieved_contexts=[context["page_content"] for context in trace.output["context"]],
-                    response=trace.output["answer"],
+            next_trace = traces[i + 1] if i < len(traces) - 1 else None
+            if next_trace:
+                input_appears_in_next_trace_chat_history = any(
+                    message["content"] == trace.input["input"] for message in next_trace.input["chat_history"]
                 )
             else:
-                sample = MultiTurnSample(
-                    user_input=trace_to_conversation(
-                        trace, answer_history
-                    ),  # contexts are not passed in to MultiTurnSample objects
-                )
-            samples.append(sample)
-            trace_ids.append(trace.id)
-            answer_history = []
+                input_appears_in_next_trace_chat_history = False
+
+            if input_appears_in_next_trace_chat_history:
+                # if input_appears_in_next_trace_chat_history = True, the message will eventually appear in
+                # the conversation of a MultiTurnSample, so do not instantiate a sample for it
+                # but do retain the answer history for when the MultiTurnSample is eventually instantiated
+                answer_history.append(trace.output["answer"])
+            else:
+                # trace is either a SingleTurnSample or the last trace defining a MultiTurnSample
+                is_single_turn_sample = len(trace.input["chat_history"]) == 1
+
+                if is_single_turn_sample:
+                    sample = SingleTurnSample(
+                        user_input=trace.input["input"],
+                        retrieved_contexts=[context["page_content"] for context in trace.output["context"]],
+                        response=trace.output["answer"],
+                    )
+                else:
+                    sample = MultiTurnSample(
+                        user_input=trace_to_conversation(
+                            trace, answer_history
+                        ),  # contexts are not passed in to MultiTurnSample objects
+                    )
+                samples.append(sample)
+                trace_ids.append(trace.id)
+                answer_history = []
 
     if return_dataset or dataset_path:
         dataset = EvaluationDataset(samples=samples)

--- a/eval/read_traces.py
+++ b/eval/read_traces.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import os
+import re
+import sys
 
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -10,6 +12,7 @@ from dsp_nesta_brain import logger
 from eval.langfuse_ragas import traces_to_samples
 from langfuse import Langfuse
 from utils import bold
+from utils import yesno
 
 
 if TYPE_CHECKING:
@@ -24,7 +27,7 @@ def is_admin(trace: TraceWithDetails) -> bool:
         "What work has Nesta done on heat pumps?",
         "Who has data science skills at Nesta?",
     ]
-    if trace.user_id == "helen":
+    if trace.user_id == "helen" or "admin_test" in trace.tags:
         return True
     return trace.input["input"].strip() in common_test_questions
 
@@ -39,14 +42,16 @@ os.environ["LANGFUSE_HOST"] = os.getenv("LANGFUSE_HOST")
 langfuse = Langfuse()
 
 filters = {
-    "from_timestamp": datetime.strptime("2024-12-10", "%Y-%m-%d"),
-    "to_timestamp": None,  # datetime.strptime('2024-12-10','%Y-%m-%d')
+    "from_timestamp": datetime.strptime("2024-12-05", "%Y-%m-%d"),
+    "to_timestamp": datetime.strptime("2024-12-10", "%Y-%m-%d"),
 }
 
-traces = langfuse.fetch_traces(**filters)
+traces = langfuse.fetch_traces(limit=100, **filters)
 traces = traces.data
 
+# print(len(traces))
 traces = [trace for trace in traces if not is_admin(trace)]
+# print(len(traces))
 
 samples, trace_ids = traces_to_samples(traces)
 
@@ -54,10 +59,31 @@ samples, trace_ids = traces_to_samples(traces)
 #   print(f'{i+1}/{len(traces)}',trace.input["input"])
 #  input()
 
-logger.info(trace_ids)
+skip = int(sys.argv[1]) if sys.argv[1:] else 0
 
-for i, sample in enumerate(samples):
-    logger.info(
-        f'\n\n{i+1}/{len(samples)} {bold(trace_ids[i])} {bold(f"[{sample.__class__.__name__}]")} {sample.pretty_repr()}'
+new_sample_marker = "--------------------------------------------"
+for i, sample in enumerate(samples[skip:]):
+
+    trace_id = trace_ids[skip + i]
+    trace = langfuse.fetch_trace(trace_id).data
+
+    context = "\n".join(
+        [
+            f"\t{doc['metadata']['title']} ({doc['metadata']['date_pub']}) {doc['metadata']['location']}"
+            for doc in trace.output["context"]
+        ]
     )
-    input()
+
+    logger.info(
+        f'\n\n\n{new_sample_marker}\n{i+skip+1}/{len(samples)} {bold(trace_id)} {bold(f"[{sample.__class__.__name__}]")} {sample.pretty_repr()}\n\n{context}'  # noqa
+    )
+
+    if yesno("\nAdd tags?:"):
+
+        answer = input("List tags separated by spaces: ")
+        if answer:
+            tags = re.split(r"\s+", answer.strip())
+            if tags:
+                langfuse.trace(id=trace_id).update(
+                    tags=tags, timestamp=trace.timestamp
+                )  # it will change the timestamp unless you deliberately keep it the same

--- a/lgraph/graph.py
+++ b/lgraph/graph.py
@@ -131,7 +131,7 @@ def test(state: State, writer: StreamWriter) -> State:
             | llm
         )
         response = chain.invoke(state)
-        state["messages"][-1].content += "\n\n" + response.content
+        state["messages"][-1].content += "<br><br>" + response.content
 
     return state
 

--- a/lgraph/graph.py
+++ b/lgraph/graph.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
 from config import DEFAULT_START_YEAR
@@ -12,8 +13,8 @@ from langgraph.graph import END
 from langgraph.graph import START
 from langgraph.graph import StateGraph
 from langgraph.types import StreamWriter
+from lgraph.prompt import currentness_comment_prompt
 from lgraph.prompt import personnel_prompt
-from lgraph.prompt import test_prompt
 from lgraph.prompt import year_constraint_prompt
 from llm.llm import default_llm as llm
 from llm.message import CustomAIMessage
@@ -26,6 +27,7 @@ if TYPE_CHECKING:
 
 
 DEFAULT_FROM_YEAR_FILTER_CONDITION = f"source.date_pub >= to_timestamp('{DEFAULT_START_YEAR}-01-01')"
+LAST_CHAT_GRAPH_NODE_NAME = "currentness_comment"
 
 # ----------retrieval graph
 
@@ -117,20 +119,28 @@ def create_retrieval_graph() -> CompiledStateGraph:  # doing it as a function to
 # ----------chat graph
 
 
-def test(state: State, writer: StreamWriter) -> State:
+currentness_comment_chain = (
+    RunnableParallel(
+        input=(lambda x: x["messages"][-2]),
+        answer=(lambda x: x["messages"][-1]),
+    )
+    | currentness_comment_prompt
+    | llm
+)
+
+
+def currentness_comment(state: State, writer: StreamWriter) -> State:
     """Test example commenting on whether context is current"""
 
-    if True:
-        chain = (
-            RunnableParallel(
-                input=(lambda x: x["messages"][-2]),
-                answer=(lambda x: x["messages"][-1]),
-                context=(lambda x: x["messages"][-1].cited_references),
-            )
-            | test_prompt
-            | llm
-        )
-        response = chain.invoke(state)
+    sub_state = deepcopy(state)
+    # the chain will interpret the references of the last CustomAIMessage as context
+    # overwrite the references with only those which were actually cited in the response
+    # it needs to be a copy as otherwise the references will be changed permanently
+    #  and won't be listed properly at the end of the answer
+    sub_state["messages"][-1].references = sub_state["messages"][-1].cited_references
+
+    response = currentness_comment_chain.invoke(sub_state)
+    if response.content:
         state["messages"][-1].content += "<br><br>" + response.content
 
     return state
@@ -143,26 +153,20 @@ def create_chat_graph(**kwargs) -> CompiledStateGraph:  # doing it as a function
 
     def call_model(
         state: State,
-    ) -> State:  # ,writer:StreamWriter):   #function defined here to avoid circular import
+    ) -> State:  # function defined here to avoid circular import
 
-        if False:
-            stream_generator = rag_chain.stream(state)
-            # for item in stream_generator:    #streaming looks as it did before if done here
-            #    writer(item)
-            state["response"] = list(stream_generator)
-        else:
-            response = rag_chain.invoke(state)
-            state["messages"].append(CustomAIMessage(response))
+        response = rag_chain.invoke(state)
+        state["messages"].append(CustomAIMessage(response))
 
         return state
 
     builder = StateGraph(State)
 
     builder.add_node("call_model", call_model)
-    builder.add_node("test", test)
+    builder.add_node("currentness_comment", currentness_comment)
     builder.add_edge(START, "call_model")
-    builder.add_edge("call_model", "test")
-    builder.add_edge("test", END)
+    builder.add_edge("call_model", "currentness_comment")
+    builder.add_edge("currentness_comment", END)
 
     return builder.compile()
 

--- a/lgraph/graph.py
+++ b/lgraph/graph.py
@@ -132,7 +132,7 @@ class ChatState(State):
 # context: List[LangchainDocument]
 
 
-def old_test(state: ChatState, writer: StreamWriter) -> ChatState:
+def test(state: ChatState, writer: StreamWriter) -> ChatState:
     """Trivial test example"""
 
     if False:
@@ -154,7 +154,7 @@ def old_test(state: ChatState, writer: StreamWriter) -> ChatState:
     return state
 
 
-def test(state: ChatState, writer: StreamWriter) -> ChatState:
+def new_test(state: ChatState, writer: StreamWriter) -> ChatState:
     """Test example commenting on whether context is current"""
 
     if False:

--- a/lgraph/graph.py
+++ b/lgraph/graph.py
@@ -71,7 +71,6 @@ def decide_if_person_page(state: State) -> State:
     return state
 
 
-# -------NODES
 def decide_if_need_time_constraint(state: State) -> State:
     """Decide if the publication date of retrieved documents should be constrained by a year range"""
 

--- a/lgraph/graph.py
+++ b/lgraph/graph.py
@@ -117,7 +117,7 @@ def create_retrieval_graph() -> CompiledStateGraph:  # doing it as a function to
 # ----------chat graph
 
 
-def test(state: State, writer: StreamWriter) -> State:
+def old_test(state: State, writer: StreamWriter) -> State:
     """Trivial test example"""
 
     if False:
@@ -138,14 +138,15 @@ def test(state: State, writer: StreamWriter) -> State:
     return state
 
 
-def new_test(state: State, writer: StreamWriter) -> State:
+def test(state: State, writer: StreamWriter) -> State:
     """Test example commenting on whether context is current"""
 
     if False:
         chain = (
             RunnableParallel(
+                input=(lambda x: x["messages"][-2]),
                 answer=(lambda x: x["messages"][-1]),
-                context=(lambda x: x["context"]),
+                context=(lambda x: x["messages"][-1].cited_references),
             )
             | test_prompt
             | llm

--- a/lgraph/graph.py
+++ b/lgraph/graph.py
@@ -117,31 +117,10 @@ def create_retrieval_graph() -> CompiledStateGraph:  # doing it as a function to
 # ----------chat graph
 
 
-def old_test(state: State, writer: StreamWriter) -> State:
-    """Trivial test example"""
-
-    if False:
-        state["response"][-1]["answer"] += "!!!!!!!!!!!!!!!!!!!!"
-
-        # items = [{'answer':string+' '} for string in re.split(' ',state['response']['answer'])]
-        # items += [{'context': state['response']['context']}]
-        for item in state["response"]:  # streaming looks rushed if this is done here. Consider:
-            # taking a look at
-            # https://colab.research.google.com/github/langchain-ai/langchain-academy/blob/main/module-3/streaming-interruption.ipynb
-            # trying for event in graph.stream(None, thread, stream_mode="updates") syntax:
-            # https://colab.research.google.com/github/langchain-ai/langchain-academy/blob/main/module-4/research-assistant.ipynb#scrollTo=37123ca7-c20b-43c1-9a71-39ba344e7ca6
-            writer(item)
-
-    else:
-        state["messages"][-1].content += "!!!!!!!!!!!!!!!!!!!"
-
-    return state
-
-
 def test(state: State, writer: StreamWriter) -> State:
     """Test example commenting on whether context is current"""
 
-    if False:
+    if True:
         chain = (
             RunnableParallel(
                 input=(lambda x: x["messages"][-2]),
@@ -152,8 +131,7 @@ def test(state: State, writer: StreamWriter) -> State:
             | llm
         )
         response = chain.invoke(state)
-        # print(response)
-        state["messages"][-1] += "\n\n" + response.content
+        state["messages"][-1].content += "\n\n" + response.content
 
     return state
 

--- a/lgraph/graph.py
+++ b/lgraph/graph.py
@@ -17,6 +17,7 @@ from langgraph.graph import START
 from langgraph.graph import StateGraph
 from langgraph.types import StreamWriter
 from lgraph.prompt import personnel_prompt
+from lgraph.prompt import test_prompt
 from lgraph.prompt import year_constraint_prompt
 from llm.llm import default_llm as llm
 from llm.tool import year_range
@@ -131,20 +132,39 @@ class ChatState(State):
 # context: List[LangchainDocument]
 
 
-def test(state: ChatState, writer: StreamWriter) -> ChatState:
+def old_test(state: ChatState, writer: StreamWriter) -> ChatState:
     """Trivial test example"""
 
-    state["response"]
-    state["response"][-1]["answer"] += "!!!!!!!!!!!!!!!!!!!!"
+    if False:
+        state["response"]
+        state["response"][-1]["answer"] += "!!!!!!!!!!!!!!!!!!!!"
 
-    # items = [{'answer':string+' '} for string in re.split(' ',state['response']['answer'])]
-    # items += [{'context': state['response']['context']}]
-    for item in state["response"]:  # streaming looks rushed if this is done here. Consider:
-        # taking a look at
-        # https://colab.research.google.com/github/langchain-ai/langchain-academy/blob/main/module-3/streaming-interruption.ipynb
-        # trying for event in graph.stream(None, thread, stream_mode="updates") syntax:
-        # https://colab.research.google.com/github/langchain-ai/langchain-academy/blob/main/module-4/research-assistant.ipynb#scrollTo=37123ca7-c20b-43c1-9a71-39ba344e7ca6
-        writer(item)
+        # items = [{'answer':string+' '} for string in re.split(' ',state['response']['answer'])]
+        # items += [{'context': state['response']['context']}]
+        for item in state["response"]:  # streaming looks rushed if this is done here. Consider:
+            # taking a look at
+            # https://colab.research.google.com/github/langchain-ai/langchain-academy/blob/main/module-3/streaming-interruption.ipynb
+            # trying for event in graph.stream(None, thread, stream_mode="updates") syntax:
+            # https://colab.research.google.com/github/langchain-ai/langchain-academy/blob/main/module-4/research-assistant.ipynb#scrollTo=37123ca7-c20b-43c1-9a71-39ba344e7ca6
+            writer(item)
+
+    else:
+        state["response"]["answer"] += "!!!!!!!!!!!!!!!!!!!"
+
+    return state
+
+
+def test(state: ChatState, writer: StreamWriter) -> ChatState:
+    """Test example commenting on whether context is current"""
+
+    if False:
+        chain = test_prompt | llm
+        input = state
+        input["answer"] = state["response"]["answer"]
+        input["context"] = state["response"]["context"]
+        response = chain.invoke(input)
+        # print(response)
+        state["response"]["answer"] += "\n\n" + response.content
 
     return state
 
@@ -158,10 +178,14 @@ def create_chat_graph(**kwargs) -> CompiledStateGraph:  # doing it as a function
         state: ChatState,
     ) -> ChatState:  # ,writer:StreamWriter):   #function defined here to avoid circular import
 
-        stream_generator = rag_chain.stream(state)
-        # for item in stream_generator:    #streaming looks as it did before if done here
-        #    writer(item)
-        state["response"] = list(stream_generator)
+        if False:
+            stream_generator = rag_chain.stream(state)
+            # for item in stream_generator:    #streaming looks as it did before if done here
+            #    writer(item)
+            state["response"] = list(stream_generator)
+        else:
+            state["response"] = rag_chain.invoke(state)
+
         return state
 
     builder = StateGraph(ChatState)

--- a/lgraph/graph.py
+++ b/lgraph/graph.py
@@ -1,23 +1,35 @@
+from __future__ import annotations
+
 import asyncio
+import importlib
+
+from typing import TYPE_CHECKING
+from typing import Dict
+from typing import List
 
 from config import DEFAULT_START_YEAR
-from dotenv import load_dotenv
 from dsp_nesta_brain import logger
 
 # from langchain_core.runnables.base import RunnableSequence
-from langchain_openai import ChatOpenAI
+from langchain_core.messages import BaseMessage
 from langgraph.graph import END
 from langgraph.graph import START
 from langgraph.graph import StateGraph
+from langgraph.types import StreamWriter
 from lgraph.prompt import personnel_prompt
 from lgraph.prompt import year_constraint_prompt
+from llm.llm import default_llm as llm
 from llm.tool import year_range
-from retrieval.retrieve import RetrieverInput
+from retrieval.retrieve import RetrieverInput as State
+
+
+if TYPE_CHECKING:
+    from langgraph.graph.state import CompiledStateGraph
 
 
 DEFAULT_FROM_YEAR_FILTER_CONDITION = f"source.date_pub >= to_timestamp('{DEFAULT_START_YEAR}-01-01')"
 
-State = RetrieverInput
+# ----------retrieval graph
 
 
 def append_filter_condition(state: State, new_filter_condition: str) -> State:
@@ -87,25 +99,85 @@ def decide_if_need_time_constraint(state: State) -> State:
 # ------------
 
 
-load_dotenv()
+def create_retrieval_graph() -> CompiledStateGraph:  # doing it as a function to avoid circular imports
+    """Compile and return a graph to assist with retrieval"""
 
-llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)  # if binding tools then llm must be a ChatModel
+    builder = StateGraph(State)
 
-builder = StateGraph(State)
+    builder.add_node("decide_if_person_page", decide_if_person_page)
+    builder.add_node("decide_if_need_time_constraint", decide_if_need_time_constraint)
+    builder.add_edge(START, "decide_if_person_page")
+    builder.add_edge("decide_if_person_page", "decide_if_need_time_constraint")
+    builder.add_edge("decide_if_need_time_constraint", END)
 
-builder.add_node("decide_if_person_page", decide_if_person_page)
-builder.add_node("decide_if_need_time_constraint", decide_if_need_time_constraint)
-builder.add_edge(START, "decide_if_person_page")
-builder.add_edge("decide_if_person_page", "decide_if_need_time_constraint")
-builder.add_edge("decide_if_need_time_constraint", END)
+    return builder.compile()
 
-graph = builder.compile()
 
 # graph = RunnableSequence(decide_if_person_page, decide_if_need_time_constraint)   #for comparison
 
 
+# ----------chat graph
+
+
+class ChatState(State):
+    """State class for chat graph"""
+
+    chat_history: List[
+        BaseMessage
+    ]  # could possible replace this with messages if ChatState were a subclass of MessagesState?
+    response: List[Dict]
+
+
+# context: List[LangchainDocument]
+
+
+def test(state: ChatState, writer: StreamWriter) -> ChatState:
+    """Trivial test example"""
+
+    state["response"]
+    state["response"][-1]["answer"] += "!!!!!!!!!!!!!!!!!!!!"
+
+    # items = [{'answer':string+' '} for string in re.split(' ',state['response']['answer'])]
+    # items += [{'context': state['response']['context']}]
+    for item in state["response"]:  # streaming looks rushed if this is done here. Consider:
+        # taking a look at
+        # https://colab.research.google.com/github/langchain-ai/langchain-academy/blob/main/module-3/streaming-interruption.ipynb
+        # trying for event in graph.stream(None, thread, stream_mode="updates") syntax:
+        # https://colab.research.google.com/github/langchain-ai/langchain-academy/blob/main/module-4/research-assistant.ipynb#scrollTo=37123ca7-c20b-43c1-9a71-39ba344e7ca6
+        writer(item)
+
+    return state
+
+
+def create_chat_graph(**kwargs) -> CompiledStateGraph:  # doing it as a function to avoid circular imports
+    """Compile and return a graph to assist with chat"""
+
+    rag_chain = importlib.import_module("llm.chain").history_aware_rag_chain(**kwargs)  # avoiding circular import
+
+    def call_model(
+        state: ChatState,
+    ) -> ChatState:  # ,writer:StreamWriter):   #function defined here to avoid circular import
+
+        stream_generator = rag_chain.stream(state)
+        # for item in stream_generator:    #streaming looks as it did before if done here
+        #    writer(item)
+        state["response"] = list(stream_generator)
+        return state
+
+    builder = StateGraph(ChatState)
+
+    builder.add_node("call_model", call_model)
+    builder.add_node("test", test)
+    builder.add_edge(START, "call_model")
+    builder.add_edge("call_model", "test")
+    builder.add_edge("test", END)
+
+    return builder.compile()
+
+
 if __name__ == "__main__":
 
+    graph = create_retrieval_graph()
     #  input = "What work has Nesta done on heat pumps?"
     # input = "Who has data science skills at Nesta?"
     # input = 'Are you a lemon?'

--- a/lgraph/graph.py
+++ b/lgraph/graph.py
@@ -4,14 +4,10 @@ import asyncio
 import importlib
 
 from typing import TYPE_CHECKING
-from typing import Dict
-from typing import List
 
 from config import DEFAULT_START_YEAR
 from dsp_nesta_brain import logger
-
-# from langchain_core.runnables.base import RunnableSequence
-from langchain_core.messages import BaseMessage
+from langchain_core.runnables.base import RunnableParallel
 from langgraph.graph import END
 from langgraph.graph import START
 from langgraph.graph import StateGraph
@@ -20,6 +16,7 @@ from lgraph.prompt import personnel_prompt
 from lgraph.prompt import test_prompt
 from lgraph.prompt import year_constraint_prompt
 from llm.llm import default_llm as llm
+from llm.message import CustomAIMessage
 from llm.tool import year_range
 from retrieval.retrieve import RetrieverInput as State
 
@@ -120,23 +117,10 @@ def create_retrieval_graph() -> CompiledStateGraph:  # doing it as a function to
 # ----------chat graph
 
 
-class ChatState(State):
-    """State class for chat graph"""
-
-    chat_history: List[
-        BaseMessage
-    ]  # could possible replace this with messages if ChatState were a subclass of MessagesState?
-    response: List[Dict]
-
-
-# context: List[LangchainDocument]
-
-
-def test(state: ChatState, writer: StreamWriter) -> ChatState:
+def test(state: State, writer: StreamWriter) -> State:
     """Trivial test example"""
 
     if False:
-        state["response"]
         state["response"][-1]["answer"] += "!!!!!!!!!!!!!!!!!!!!"
 
         # items = [{'answer':string+' '} for string in re.split(' ',state['response']['answer'])]
@@ -149,22 +133,26 @@ def test(state: ChatState, writer: StreamWriter) -> ChatState:
             writer(item)
 
     else:
-        state["response"]["answer"] += "!!!!!!!!!!!!!!!!!!!"
+        state["messages"][-1].content += "!!!!!!!!!!!!!!!!!!!"
 
     return state
 
 
-def new_test(state: ChatState, writer: StreamWriter) -> ChatState:
+def new_test(state: State, writer: StreamWriter) -> State:
     """Test example commenting on whether context is current"""
 
     if False:
-        chain = test_prompt | llm
-        input = state
-        input["answer"] = state["response"]["answer"]
-        input["context"] = state["response"]["context"]
-        response = chain.invoke(input)
+        chain = (
+            RunnableParallel(
+                answer=(lambda x: x["messages"][-1]),
+                context=(lambda x: x["context"]),
+            )
+            | test_prompt
+            | llm
+        )
+        response = chain.invoke(state)
         # print(response)
-        state["response"]["answer"] += "\n\n" + response.content
+        state["messages"][-1] += "\n\n" + response.content
 
     return state
 
@@ -175,8 +163,8 @@ def create_chat_graph(**kwargs) -> CompiledStateGraph:  # doing it as a function
     rag_chain = importlib.import_module("llm.chain").history_aware_rag_chain(**kwargs)  # avoiding circular import
 
     def call_model(
-        state: ChatState,
-    ) -> ChatState:  # ,writer:StreamWriter):   #function defined here to avoid circular import
+        state: State,
+    ) -> State:  # ,writer:StreamWriter):   #function defined here to avoid circular import
 
         if False:
             stream_generator = rag_chain.stream(state)
@@ -184,11 +172,12 @@ def create_chat_graph(**kwargs) -> CompiledStateGraph:  # doing it as a function
             #    writer(item)
             state["response"] = list(stream_generator)
         else:
-            state["response"] = rag_chain.invoke(state)
+            response = rag_chain.invoke(state)
+            state["messages"].append(CustomAIMessage(response))
 
         return state
 
-    builder = StateGraph(ChatState)
+    builder = StateGraph(State)
 
     builder.add_node("call_model", call_model)
     builder.add_node("test", test)

--- a/lgraph/prompt.py
+++ b/lgraph/prompt.py
@@ -46,4 +46,21 @@ date_constraint_prompt_template = f"""
     {{input}}
     """  # noqa
 
-date_constraint_prompt = PromptTemplate(template=date_constraint_prompt_template, input_variables=["input"])
+date_constraint_prompt = PromptTemplate(template=date_constraint_prompt_template, input_variables=["input", "answer"])
+
+
+test_prompt_template = f"""
+    You are a helpful RAG system and an expert on the internal administration, personnel and projects of the innovation agency Nesta. The year is currently {datetime.now().year}.
+
+    You were asked to search for documents relevant to the question below and provided an answer and appropriate context.
+
+    Look at the context metadata and comment on whether the answer to your question was likely to be currently correct.
+
+    Question:
+    {{input}}
+
+    Answer:
+    {{answer}}
+    """  # noqa
+
+test_prompt = PromptTemplate(template=test_prompt_template, input_variables=["input"])

--- a/lgraph/prompt.py
+++ b/lgraph/prompt.py
@@ -49,7 +49,7 @@ date_constraint_prompt_template = f"""
 date_constraint_prompt = PromptTemplate(template=date_constraint_prompt_template, input_variables=["input", "answer"])
 
 
-test_prompt_template = f"""
+currentness_comment_prompt_template_1 = f"""
     You are a helpful RAG system and an expert on the internal administration, personnel and projects of the innovation agency Nesta. The year is currently {datetime.now().year}.
 
     You were asked to search for documents relevant to the question below and provided an answer and appropriate context.
@@ -63,4 +63,50 @@ test_prompt_template = f"""
     {{answer}}
     """  # noqa
 
-test_prompt = PromptTemplate(template=test_prompt_template, input_variables=["input"])
+currentness_comment_prompt_template_2 = f"""
+    You are a helpful RAG system and an expert on the internal administration, personnel and projects of the innovation agency Nesta. The year is currently {datetime.now().year}.
+
+    You were asked to search for documents relevant to the question below and you provided an answer and appropriate context. However, the answer might be based on out-of-date context.
+
+    Look at the context metadata and rephrase the answer based on assessment of whether the context is providing up-to-date information. Express doubt about the answer if it isn't. Limit your answer to 100 words.
+
+    Question:
+    {{input}}
+
+    Answer:
+    {{answer}}
+    """  # noqa
+
+
+currentness_comment_prompt_template_3 = f"""
+    You are a helpful RAG system and an expert on the internal administration, personnel and projects of the innovation agency Nesta. Today's date is {datetime.now().date()}.
+
+    You were asked to search for documents relevant to the question below and you provided an answer and appropriate context. However, the answer might be based on out-of-date context.
+
+    Look at the context metadata and assess whether the context is providing up-to-date information. If the context is over a year old, mention that the information on which you are basing your answer could be out of date. Limit your answer to 100 words.
+
+    Question:
+    {{input}}
+
+    Answer:
+    {{answer}}
+    """  # noqa
+
+
+currentness_comment_prompt_template_4 = f"""
+    You are a helpful RAG system and an expert on the internal administration, personnel and projects of the innovation agency Nesta. Today's date is {datetime.now().date()}.
+
+    You were asked to search for documents relevant to the question below and you provided an answer and appropriate context. However, the answer might be based on out-of-date context.
+
+    Look at the context metadata. If the context is over a year old, mention that the information on which you are basing your answer could be out of date. Limit your answer to 50 words. If all of the context is less than a year old, return an empty string.
+
+    Question:
+    {{input}}
+
+    Answer:
+    {{answer}}
+    """  # noqa
+
+currentness_comment_prompt = PromptTemplate(
+    template=currentness_comment_prompt_template_4, input_variables=["input", "answer"]
+)

--- a/llm/chain.py
+++ b/llm/chain.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Callable
 from typing import Dict
 
 from langchain.chains.combine_documents import create_stuff_documents_chain
@@ -45,7 +44,9 @@ def create_retrieval_chain(
 
 
 def rag_chain_with_citation_tool(
-    retriever: BaseRetriever, llm: BaseChatModel, prompt: PromptTemplate, chat_history_func: Callable
+    retriever: BaseRetriever,
+    llm: BaseChatModel,
+    prompt: PromptTemplate,
 ) -> Runnable:
     """Return a RAG retrieval chain with incorporating a tool for capturing citations"""
 
@@ -63,7 +64,9 @@ def rag_chain_with_citation_tool(
     answer = prompt | llm_with_tool | output_parser
     chain = (
         RunnableParallel(
-            input=(lambda x: x["input"]), context=(lambda x: x["context"]), chat_history=chat_history_func
+            input=(lambda x: x["messages"][-1]),
+            context=(lambda x: x["context"]),
+            chat_history=(lambda x: x["messages"][0:-1]),
         )
         .assign(quoted_answer=answer)
         .pick(["quoted_answer"])
@@ -80,6 +83,6 @@ def history_aware_rag_chain(**kwargs) -> Runnable:
     return create_retrieval_chain(history_aware_retriever(**kwargs), chat_qa_chain)
 
 
-def history_aware_rag_chain_with_citation_tool(chat_history_func: Callable, **kwargs) -> Runnable:
+def history_aware_rag_chain_with_citation_tool(**kwargs) -> Runnable:
     """Return a history aware RAG chain with citation tool while passing kwargs through to history_aware_retriever"""
-    return rag_chain_with_citation_tool(history_aware_retriever(**kwargs), llm, qa_prompt, chat_history_func)
+    return rag_chain_with_citation_tool(history_aware_retriever(**kwargs), llm, qa_prompt)

--- a/llm/message.py
+++ b/llm/message.py
@@ -53,7 +53,6 @@ class CustomAIMessage(AIMessage):
     """An extension of LangChain's AIMessage just to make things like printing and writing responses to streamlit easier"""
 
     references: List[Reference]
-    trace_id: Optional[str] = None  # may need trace ids to push feedback to Langfuse
 
     class Config:  # noqa
         arbitrary_types_allowed = True

--- a/llm/message.py
+++ b/llm/message.py
@@ -31,7 +31,7 @@ class Reference(LangchainDocument):
 
     def as_html(self, reset_index: bool = False) -> str:
         """Return reference metadata as an anchor element (indexed)"""
-        test_mode = True
+        test_mode = False
         index = self.reset_index if reset_index else self.index
         if test_mode:
             if self.index == 1:
@@ -50,7 +50,7 @@ class Reference(LangchainDocument):
 
 
 class CustomAIMessage(AIMessage):
-    """An extension of LangChain's AIMessage just to make things like printing and writing responses to streamlit easier"""
+    """An extension of LangChain's AIMessage just to make printing and writing responses to streamlit easier"""
 
     references: List[Reference]
 

--- a/llm/message.py
+++ b/llm/message.py
@@ -29,9 +29,9 @@ class Reference(LangchainDocument):
         """Test whether the underlying source document is a PDF"""
         return self.metadata["location"].lower()[-4:] == ".pdf"
 
-    def as_html(self, reset_index: bool = False, test_mode: bool = False) -> str:
+    def as_html(self, reset_index: bool = False) -> str:
         """Return reference metadata as an anchor element (indexed)"""
-        test_mode = True
+        test_mode = False
         index = self.reset_index if reset_index is not None else self.index
         if test_mode:
             if self.index == 1:

--- a/llm/message.py
+++ b/llm/message.py
@@ -15,7 +15,16 @@ from langchain_core.messages import AIMessage
 
 
 class Reference(LangchainDocument):
-    """Extends the LangchainDocument class to make inline citations easier"""
+    """
+    Class to represent retrieved documents for the purposes of presentation, and for making in-line citations easier.
+
+    index:  the initial index of the reference representing its position in the list of retrieved documents
+            (starting at 1, not 0); this is the index which the LLM 'sees' for the purposes of inline citations
+    reset_index: the final index of the reference for presentational purposes, given that references are reordered so that
+                 those which are cited appear before those which weren't cited
+                 (see `reset_reference_indices` method of CustomAIMessage)
+    cited: whether the document was used as an in-line citation or not
+    """
 
     index: int
     reset_index: Optional[int] = None
@@ -73,7 +82,7 @@ class CustomAIMessage(AIMessage):
         super().__init__(content=content, references=references)
 
     def __repr__(self) -> str:
-        """Self-explanatory"""
+        """Return string representation"""
         string = "\n--------------\n" + self.content
         string += f'\n{self.references[0].page_content}\n{self.references[0].metadata["location"]}'
         string += "\n--------------\n\n"

--- a/llm/message.py
+++ b/llm/message.py
@@ -29,10 +29,10 @@ class Reference(LangchainDocument):
         """Test whether the underlying source document is a PDF"""
         return self.metadata["location"].lower()[-4:] == ".pdf"
 
-    def as_html(self, reset_index: bool = False) -> str:
+    def as_html(self, reset_index: bool = False, test_mode: bool = False) -> str:
         """Return reference metadata as an anchor element (indexed)"""
-        test_mode = False
-        index = self.reset_index if reset_index else self.index
+        test_mode = True
+        index = self.reset_index if reset_index is not None else self.index
         if test_mode:
             if self.index == 1:
                 logger.warning(
@@ -44,9 +44,8 @@ class Reference(LangchainDocument):
 
     def as_superscript(self, reset_index: bool = False) -> str:
         """Return index as a clickable link within a superscript, suitable for inline citations"""
-        return (
-            f'<sup><a href="{self.metadata["location"]}">{self.reset_index if reset_index else self.index}</a></sup>'
-        )
+        index = self.reset_index if reset_index is not None else self.index
+        return f'<sup><a href="{self.metadata["location"]}">{index}</a></sup>'
 
 
 class CustomAIMessage(AIMessage):
@@ -93,6 +92,8 @@ class CustomAIMessage(AIMessage):
     @property
     def cited_references(self) -> List[Reference]:
         """Return a list of references which are actually cited in the content"""
+        if not self.citations_have_been_flagged:
+            self.flag_citations()
         return [reference for reference in self.references if reference.cited]
 
     @property
@@ -122,7 +123,8 @@ class CustomAIMessage(AIMessage):
         because they are part of the answer
         """
 
-        self.reset_reference_indices()
+        if not self.reference_indices_have_been_reset:
+            self.reset_reference_indices()
 
         content = markdown.markdown(self.content)
         N_references = len(self.references)
@@ -142,18 +144,37 @@ class CustomAIMessage(AIMessage):
     @property
     def uncited_references(self) -> List[Reference]:
         """Return a list of references which are not cited in the content"""
+        if not self.citations_have_been_flagged:
+            self.flag_citations()
         return [reference for reference in self.references if not reference.cited]
+
+    @property
+    def citations_have_been_flagged(self) -> bool:
+        """
+        Test whether any of the references have cited property set to True.
+
+        Also return True if there are no citations
+        """
+
+        return any(reference.cited for reference in self.references) or not self.citations_in_content
+
+    @property
+    def reference_indices_have_been_reset(self) -> bool:
+        """Test whether the references' reset_index has been set"""
+        return all(reference.reset_index is not None for reference in self.references)
 
     def as_html(self) -> str:
         """Convert the response into HTML"""
         return f'<div class="response">{self.p_element}{self.references_}</div>'
 
-    def reset_reference_indices(self) -> None:
-        """Reset how the reference numbering will appear if references are split into cited and uncited sources"""
+    def flag_citations(self) -> None:
+        """Flag references which have been cited"""
         for citation in self.citations_in_content:
             citation_index = int(citation[1:-1])
             reference = self.references[citation_index - 1]
             reference.cited = True
 
+    def reset_reference_indices(self) -> None:
+        """Reset how the reference numbering will appear if references are split into cited and uncited sources"""
         for i, reference in enumerate(self.cited_references + self.uncited_references):
             reference.reset_index = i + 1

--- a/llm/message.py
+++ b/llm/message.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import logging
+import re
+
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from dsp_nesta_brain import logger
+from langchain.docstore.document import Document as LangchainDocument
+from langchain_core.messages import AIMessage
+
+
+class Reference(LangchainDocument):
+    """Extends the LangchainDocument class to make inline citations easier"""
+
+    index: int
+    reset_index: Optional[int] = None
+    cited: bool = False
+
+    def __init__(self, chunk: LangchainDocument, index: int) -> None:
+        super().__init__(page_content=chunk.page_content, metadata=chunk.metadata, index=index)
+
+    @property
+    def is_pdf(self) -> bool:
+        """Test whether the underlying source document is a PDF"""
+        return self.metadata["location"].lower()[-4:] == ".pdf"
+
+    def as_html(self, reset_index: bool = False) -> str:
+        """Return reference metadata as an anchor element (indexed)"""
+        test_mode = True
+        index = self.reset_index if reset_index else self.index
+        if test_mode:
+            if self.index == 1:
+                logger.warning(
+                    "Formatting of links for testing retrieval filtering is in use – do not use for production"
+                )
+            return f'<a href="{self.metadata["location"]}">[{index}] {self.metadata["title"]}{" (PDF)" if self.is_pdf else ""} {self.metadata["date_pub"]} {self.metadata["contentType"]} {self.metadata["missions"]}</a>'  # noqa
+        else:
+            return f'<a href="{self.metadata["location"]}">[{index}] {self.metadata["title"]}{" (PDF)" if self.is_pdf else ""}</a>'  # noqa
+
+    def as_superscript(self, reset_index: bool = False) -> str:
+        """Return index as a clickable link within a superscript, suitable for inline citations"""
+        return (
+            f'<sup><a href="{self.metadata["location"]}">{self.reset_index if reset_index else self.index}</a></sup>'
+        )
+
+
+class CustomAIMessage(AIMessage):
+    """An extension of LangChain's AIMessage just to make things like printing and writing responses to streamlit easier"""
+
+    references: List[Reference]
+    trace_id: Optional[str] = None  # may need trace ids to push feedback to Langfuse
+
+    class Config:  # noqa
+        arbitrary_types_allowed = True
+
+    def __init__(self, chain_response: Dict) -> None:
+
+        if type(chain_response["answer"]) is str:
+            content = chain_response["answer"]
+        elif isinstance(
+            chain_response["answer"], dict
+        ):  # this will be the case if a tool has been used for citations:
+            # see quoted_answer class in llm/tool.py
+            # use isinstance, not type
+            content = chain_response["answer"]["quoted_answer"]
+
+        chunks = chain_response["context"]
+        references = [Reference(chunk, i + 1) for i, chunk in enumerate(chunks)]
+
+        super().__init__(content=content, references=references)
+
+    def __repr__(self) -> str:
+        """Self-explanatory"""
+        string = "\n--------------\n" + self.content
+        string += f'\n{self.references[0].chunk.page_content}\n{self.references[0].metadata["location"]}'
+        string += "\n--------------\n\n"
+        return string
+
+    @property
+    def a_elements(self) -> str:
+        """Return hyperlink(s) to source document(s)"""
+        return [reference.as_html() for reference in self.references]
+
+    @property
+    def citations_in_content(self) -> List[str]:
+        """Return the set of citations in the content, i.e. numbers appearing in square brackets"""
+        return set(re.findall(r"\[\d+\]", self.content))
+
+    @property
+    def cited_references(self) -> List[Reference]:
+        """Return a list of references which are actually cited in the content"""
+        return [reference for reference in self.references if reference.cited]
+
+    @property
+    def p_element(self) -> str:
+        """Return content as an HTML paragraph"""
+        return f"<p>{self.content_with_superscript_citations}</p>"
+
+    @property
+    def references_(self) -> str:
+        """Return formatted reference list"""
+        cited = [reference.as_html(reset_index=True) for reference in self.cited_references]
+        not_cited = [reference.as_html(reset_index=True) for reference in self.uncited_references]
+        actual_references = "<br><br><em>Cited references:</em><br>" + "<br>".join(cited) if cited else ""
+        the_rest = (
+            f"<br><em>{'May be useful' if cited else 'May be useful'}:</em><br>" + "<br>".join(not_cited)
+            if not_cited
+            else ""
+        )
+        return actual_references + the_rest
+
+    @property
+    def content_with_superscript_citations(self) -> str:
+        """
+        Return content converting all citations in square brackets to a clickable superscript
+
+        Note: we may encounter problems if for some reason numbers within square brackets appear in the content
+        because they are part of the answer
+        """
+
+        self.reset_reference_indices()
+
+        content = self.content
+        N_references = len(self.references)
+        for citation in self.citations_in_content:
+            citation_index = int(citation[1:-1])  # remove the square brackets
+            if citation_index <= N_references:  # citation indices are in the range 1:N rather than 0:(N-1)
+                reference = self.references[citation_index - 1]
+                superscript = reference.as_superscript(reset_index=True)
+                content = content.replace(citation, superscript)
+            else:
+                logging.warning(f"Citation {citation} contained an index greater than the number of references")
+        content = content.replace(
+            "</sup><sup>", ","
+        )  # where there are citations next to each other, merge them into the same superscript and separate them with commas
+        return content
+
+    @property
+    def uncited_references(self) -> List[Reference]:
+        """Return a list of references which are not cited in the content"""
+        return [reference for reference in self.references if not reference.cited]
+
+    def as_html(self) -> str:
+        """Convert the response into HTML"""
+        return f'<div class="response">{self.p_element}{self.references_}</div>'
+
+    def reset_reference_indices(self) -> None:
+        """Reset how the reference numbering will appear if references are split into cited and uncited sources"""
+        for citation in self.citations_in_content:
+            citation_index = int(citation[1:-1])
+            reference = self.references[citation_index - 1]
+            reference.cited = True
+
+        for i, reference in enumerate(self.cited_references + self.uncited_references):
+            reference.reset_index = i + 1

--- a/llm/message.py
+++ b/llm/message.py
@@ -7,6 +7,8 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
+import markdown
+
 from dsp_nesta_brain import logger
 from langchain.docstore.document import Document as LangchainDocument
 from langchain_core.messages import AIMessage
@@ -75,7 +77,7 @@ class CustomAIMessage(AIMessage):
     def __repr__(self) -> str:
         """Self-explanatory"""
         string = "\n--------------\n" + self.content
-        string += f'\n{self.references[0].chunk.page_content}\n{self.references[0].metadata["location"]}'
+        string += f'\n{self.references[0].page_content}\n{self.references[0].metadata["location"]}'
         string += "\n--------------\n\n"
         return string
 
@@ -104,7 +106,7 @@ class CustomAIMessage(AIMessage):
         """Return formatted reference list"""
         cited = [reference.as_html(reset_index=True) for reference in self.cited_references]
         not_cited = [reference.as_html(reset_index=True) for reference in self.uncited_references]
-        actual_references = "<br><br><em>Cited references:</em><br>" + "<br>".join(cited) if cited else ""
+        actual_references = "<br><em>Cited references:</em><br>" + "<br>".join(cited) if cited else ""
         the_rest = (
             f"<br><em>{'May be useful' if cited else 'May be useful'}:</em><br>" + "<br>".join(not_cited)
             if not_cited
@@ -123,7 +125,7 @@ class CustomAIMessage(AIMessage):
 
         self.reset_reference_indices()
 
-        content = self.content
+        content = markdown.markdown(self.content)
         N_references = len(self.references)
         for citation in self.citations_in_content:
             citation_index = int(citation[1:-1])  # remove the square brackets

--- a/llm/prompt.py
+++ b/llm/prompt.py
@@ -77,8 +77,7 @@ qa_system_prompt = """
 qa_prompt = ChatPromptTemplate.from_messages(
     [
         ("system", qa_system_prompt),
-        MessagesPlaceholder("chat_history"),
-        ("human", "{input}"),
+        MessagesPlaceholder("messages"),
     ]
 )
 
@@ -93,7 +92,6 @@ just reformulate it if needed and otherwise return it as is."""
 contextualize_q_prompt = ChatPromptTemplate.from_messages(
     [
         ("system", contextualize_q_system_prompt),
-        MessagesPlaceholder("chat_history"),
-        ("human", "{input}"),
+        MessagesPlaceholder("messages"),
     ]
 )

--- a/poetry.lock
+++ b/poetry.lock
@@ -3243,6 +3243,21 @@ htmlsoup = ["BeautifulSoup4"]
 source = ["Cython (>=3.0.11)"]
 
 [[package]]
+name = "markdown"
+version = "3.7"
+description = "Python implementation of John Gruber's Markdown."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "Markdown-3.7-py3-none-any.whl", hash = "sha256:7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803"},
+    {file = "markdown-3.7.tar.gz", hash = "sha256:2ae2471477cfd02dbbf038d5d9bc226d40def84b4fe2986e49b59b6b472bbed2"},
+]
+
+[package.extras]
+docs = ["mdx-gh-links (>=0.2)", "mkdocs (>=1.5)", "mkdocs-gen-files", "mkdocs-literate-nav", "mkdocs-nature (>=0.6)", "mkdocs-section-index", "mkdocstrings[python]"]
+testing = ["coverage", "pyyaml"]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
@@ -8148,4 +8163,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "a3986790a26f8d02f385de52a07bc1ff916edceace7f892b30bf91e5ed6fb316"
+content-hash = "6e659ded3814a621e9eca2e97a013d878660a249bf792e521146d5dcc7286384"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ streamlit-feedback = "^0.1.3"
 langfuse = "^2.54.1"
 ragas = "^0.2.5"
 langgraph = "^0.2.53"
+markdown = "^3.7"
 
 
 [tool.poetry.group.test]

--- a/retrieval/chain.py
+++ b/retrieval/chain.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from langchain_core.runnables import RunnableBranch
 from langchain_core.runnables import RunnableParallel
-from lgraph.graph import graph
+from lgraph.graph import create_retrieval_graph
 from llm.llm import default_llm as llm
 from llm.prompt import contextualize_q_prompt
 from retrieval.retrieve import CustomRetriever
@@ -59,7 +59,10 @@ def retriever(use_langgraph: bool = False) -> Runnable:
     retriever_ = CustomRetriever()
     if use_langgraph:
         retriever_ = (
-            graph | (lambda x: x[-1] if type(x) is list else x) | (lambda d: d.popitem()[1]) | retriever_
+            create_retrieval_graph()
+            | (lambda x: x[-1] if type(x) is list else x)
+            | (lambda d: d.popitem()[1])
+            | retriever_
         )  # the lambdas here ensure that whatever comes out of the graph is a dict representing the final state
         # (it should have the same keys as RetrieverInput)
         # the format of graph outputs is:

--- a/retrieval/chain.py
+++ b/retrieval/chain.py
@@ -58,15 +58,22 @@ def retriever(use_langgraph: bool = False) -> Runnable:
     """Return a CustomRetriever with the option of chaining it with a graph in order to make retrieval more sophisticated"""
     retriever_ = CustomRetriever()
     if use_langgraph:
+
+        # the output of the graph is a list of dicts in this format:
+        # List[{'node_1_name':dict representing state returned by node 1} .. {'node_n_name': state returned by node n}]
+        # the intermediate steps in the chain here transform this graph output into a useful input for retriever_,
+        # that is a single dict representing the final graph state
+        # This final state should have the same keys as RetrieverInput
+
         retriever_ = (
             create_retrieval_graph()
-            | (lambda x: x[-1] if type(x) is list else x)
-            | (lambda d: d.popitem()[1])
+            | (
+                lambda x: x[-1] if type(x) is list else x
+            )  # The output of this is this dict: {'node_n_name': state returned by node n}
+            | (lambda d: d.popitem()[1])  # This output of this is a dict representing the state returned by node n
             | retriever_
-        )  # the lambdas here ensure that whatever comes out of the graph is a dict representing the final state
-        # (it should have the same keys as RetrieverInput)
-        # the format of graph outputs is:
-        # List[{'node_1_name':dict representing state returned by node 1} .. {'node_n_name': state returned by node n}]
+        )
+
     return retriever_
 
 

--- a/retrieval/chain.py
+++ b/retrieval/chain.py
@@ -59,21 +59,19 @@ def retriever(use_langgraph: bool = False) -> Runnable:
     retriever_ = CustomRetriever()
     if use_langgraph:
 
-        # the output of the graph is a list of dicts in this format:
-        # List[{'node_1_name':dict representing state returned by node 1} .. {'node_n_name': state returned by node n}]
-        # the intermediate steps in the chain here transform this graph output into a useful input for retriever_,
-        # that is a single dict representing the final graph state
-        # This final state should have the same keys as RetrieverInput
-
         retriever_ = (
-            create_retrieval_graph()
-            | (
-                lambda x: x[-1] if type(x) is list else x
-            )  # The output of this is this dict: {'node_n_name': state returned by node n}
-            | (lambda d: d.popitem()[1])  # This output of this is a dict representing the state returned by node n
-            | retriever_
-        )
-
+        # Create a retrieval graph, which returns a list of dicts with node outputs, such as:
+        # List[{'node_1_name':dict representing state returned by node 1} .. 
+        # {'node_n_name': state returned by node n}]
+        create_retrieval_graph()
+        # Extract the last element
+        | (lambda x: x[-1] if type(x) is list else x)
+        # Extract the value from a dictionary by removing its only key-value pair, and returning only the value
+        | (lambda d: d.popitem()[1])
+        # Pass the refined output into the CustomRetriever for final retrieval processing
+        | retriever_
+    )
+    
     return retriever_
 
 

--- a/retrieval/db/ingest.py
+++ b/retrieval/db/ingest.py
@@ -501,7 +501,7 @@ def urls_to_ingested_data(
         scraped_datum = scrape(url)
 
         if scraped_datum and scraped_datum["text"]:
-            metadata = {k: v for k, v in scraped_datum.items() if k in ["title", "date_pub"]}
+            metadata = {k: v for k, v in scraped_datum.items() if k != "text"}
             metadata["location"] = url
             doc = LangchainDocument(page_content=scraped_datum["text"], metadata=metadata)
             docs.append(doc)

--- a/retrieval/db/ingest.py
+++ b/retrieval/db/ingest.py
@@ -6,8 +6,10 @@ import sys
 
 from datetime import datetime
 from typing import List
+from typing import Literal
 from typing import Optional
 from typing import Tuple
+from typing import Type
 from typing import Union
 
 import lancedb
@@ -17,6 +19,9 @@ import tiktoken
 from bs4 import BeautifulSoup
 from bs4.element import Tag
 from config import DB_PATH
+from config import DEFAULT_EMBEDDINGS_MODEL
+from config import RPM_RATE_LIMIT
+from config import TPM_RATE_LIMIT
 from dotenv import load_dotenv
 from dsp_nesta_brain import PROJECT_DIR
 from dsp_nesta_brain import logger
@@ -28,6 +33,7 @@ from pdf2image.exceptions import PDFInfoNotInstalledError
 from retrieval.db.schema import Chunk
 from retrieval.db.schema import Document as LanceDocument
 from scraping.scrape import html_to_text
+from scraping.scrape import scrape
 from scraping.scrape import search_query_to_scraped_data
 from scraping.scrape_pdf import PDF
 from utils import unique
@@ -36,6 +42,7 @@ from utils import unique
 _prefix = "2024-10-29"
 WEBSITE_DATA_PATH = PROJECT_DIR / f"scraping/data/website_{_prefix}"
 PDF_PATH = WEBSITE_DATA_PATH / "pdf_files"
+METADATA_PATH = WEBSITE_DATA_PATH / "metadata.jsonl"
 NESTA_SITE_URL = "https://nesta.org.uk"
 
 CHUNK_SIZE = 2000
@@ -45,8 +52,6 @@ OPENAI_ENCODING = "cl100k_base"
 
 # OpenAI limits
 request_count = {}
-RPM_RATE_LIMIT = 10000
-TPM_RATE_LIMIT = 5e6
 
 load_dotenv()
 
@@ -148,7 +153,7 @@ async def chunk_to_Chunk(chunk: LangchainDocument, order_index: int, source: Lan
     # using model.VectorField() specified in the schema.
     # This is because I had issues getting the nested schema to work with this method.
     async_client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-    result = await async_client.embeddings.create(model="text-embedding-3-small", input=chunk.page_content)
+    result = await async_client.embeddings.create(model=DEFAULT_EMBEDDINGS_MODEL, input=chunk.page_content)
     vector = result.data[0].embedding
     return Chunk(text=chunk.page_content, source=source, vector=vector, order_index=order_index)
 
@@ -236,7 +241,7 @@ def ingest(documents: List[LangchainDocument], replace: bool = False) -> None:
         # If the title of a record in the document table is updated,
         # the source.title for the relevant chunk records remains the same
         # This is a recipe for mess!
-        # I am keeping this in temporarily for purposes of experimentation
+        # This was introduced temporarily for purposes of experimentation
         if chunks:
             logger.info(f"Ingested {len(lance_documents)} Document(s) and {len(chunks)} Chunks to the database")
             document_table.add(lance_documents)
@@ -254,7 +259,7 @@ def ingest(documents: List[LangchainDocument], replace: bool = False) -> None:
 def webpages_to_ingested_data(
     uids: Optional[List[str]] = None,
     df: Optional[pd.DataFrame] = None,
-    replace: bool = False,
+    **kwargs,
 ) -> None:
     """Convert dumped Nesta webpages into LangchainDocuments and ingest"""
 
@@ -264,8 +269,8 @@ def webpages_to_ingested_data(
         )
 
     if uids:
-        metadata_path = WEBSITE_DATA_PATH / "metadata.jsonl"  # noqa
-        metadata_df = pd.read_json(metadata_path, lines=True)
+        METADATA_PATH = WEBSITE_DATA_PATH / "metadata.jsonl"  # noqa
+        metadata_df = pd.read_json(METADATA_PATH, lines=True)
         rows = [metadata_df[metadata_df["uid"] == uid].iloc[0] for uid in uids]
         df = pd.DataFrame(rows)
 
@@ -301,7 +306,7 @@ def webpages_to_ingested_data(
             )  # this is the case for some types of long read e.g. https://www.nesta.org.uk/feature/mapping-early-years-practice/
 
     if docs:
-        ingest(docs, replace=replace)
+        ingest(docs, **kwargs)
 
     else:
         logger.info("No docs to ingest!")
@@ -361,7 +366,7 @@ def is_good_link(link: str) -> bool:
 
 # if scraping/ingesting PDFs from entire Nesta website data dump
 def pdfs_to_ingested_data(
-    df: pd.DataFrame, replace: bool = False, download_button_pdf_only: bool = False, cautious: bool = False
+    df: pd.DataFrame, download_button_pdf_only: bool = False, cautious: bool = False, **kwargs
 ) -> None:
     """Convert dumped Nesta website PDFs into LangchainDocuments and ingest"""
 
@@ -384,15 +389,16 @@ def pdfs_to_ingested_data(
 
             #   print("\n\n", button_links_doc_titles, "\n\n")
 
-            desirable_file_name_and_link_tuples = [  #stores the file names and links just of the PDFs we're interested in 
-                                                     #according to some criterion – here the criterion is that the link is 
-                                                     #contained in a download button (indicating a major publication)
-                (file_names.get(link), link, title_guess) for link, title_guess in button_links_doc_titles
+            desirable_file_name_and_link_tuples = [  # stores the file names and links just of the PDFs we're interested in
+                # according to some criterion – here the criterion is that the link is
+                # contained in a download button (indicating a major publication)
+                (file_names.get(link), link, title_guess)
+                for link, title_guess in button_links_doc_titles
             ]
 
         else:
-            desirable_file_name_and_link_tuples = [   #see comment above. Here the criterion is simply that the PDF
-                                                    #is on the Nesta website and not an external website
+            desirable_file_name_and_link_tuples = [  # see comment above. Here the criterion is simply that the PDF
+                # is on the Nesta website and not an external website
                 (
                     file_name,
                     link,
@@ -410,9 +416,9 @@ def pdfs_to_ingested_data(
                 else:
                     path = link
 
-                if cautious:   #if being cautious, you will be asked to decide whether you want to scrape the PDF and
-                                #whether the metadata guesses are correct. This opens the PDF and its corresponding
-                                #webpage for examination
+                if cautious:  # if being cautious, you will be asked to decide whether you want to scrape the PDF and
+                    # whether the metadata guesses are correct. This opens the PDF and its corresponding
+                    # webpage for examination
                     logging.info(f"Opening {file_name}")
                     os.system(f"open {path}")  # nosec
                     os.system(f'open {row["url"]}')  # nosec
@@ -455,7 +461,7 @@ def pdfs_to_ingested_data(
             # this gap in the messages helps keep it readable
 
     if docs:
-        ingest(docs, replace=replace)
+        ingest(docs, **kwargs)
 
     else:
         logger.info("No PDF-derived docs to ingest for this batch")
@@ -481,40 +487,74 @@ def search_query_to_ingested_data(query: str, site_url: str, replace: bool = Fal
     return bool(scraped_data)
 
 
+def urls_to_ingested_data(
+    urls: List[str],
+    **kwargs,
+) -> None:
+    """Convert the webpages pointed to by urls into LangchainDocuments and ingest"""
+
+    docs = []
+    for url in urls:
+
+        logger.info(f"Scraping webpage {url}")
+
+        scraped_datum = scrape(url)
+
+        if scraped_datum and scraped_datum["text"]:
+            metadata = {k: v for k, v in scraped_datum.items() if k in ["title", "date_pub"]}
+            metadata["location"] = url
+            doc = LangchainDocument(page_content=scraped_datum["text"], metadata=metadata)
+            docs.append(doc)
+
+        else:
+            logger.info(f"Webpage {url} failed to scrape and/or did not seem to have any text")
+
+    if docs:
+        ingest(docs, **kwargs)
+
+    else:
+        logger.info("No docs to ingest!")
+
+
 if __name__ == "__main__":
 
     # SETTINGS
-    mode = "web_dump"  # if 'web_search', do a web search, scrape and ingest the results
+    mode_type: Type = Literal["web_dump", "web_search", "given_urls"]
+    mode: mode_type = "web_dump"  # if 'web_search', do a web search, scrape and ingest the results  # noqa
     # if 'web_dump', ingest data which has already been downloaded from the Nesta website
-    possible_modes = ["web_dump", "web_search"]
-    replace = False  # if True, if the document already exists in the DB, any chunks derived
+    # if 'given_urls', provide a list of known urls
+    replace: bool = False  # if True, if the document already exists in the DB, any chunks derived
     # from it will be deleted and replaced
 
     # settings relevant to web_dump mode
-    pdf_mode = True  # scrape PDFs rather than webpages
-    download_button_pdf_only = True  # only scrape PDfs if they are a major research output indicated on the page
+    pdf_mode: bool = False  # scrape PDFs rather than webpages
+    download_button_pdf_only: bool = True  # only scrape PDfs if they are a major research output indicated on the page
     # by being downloadable by clicking a big red button
-    cautious = False  # ask whether you want to scrape the PDF and whether the metadata guesses are correct
-    metadata_path = WEBSITE_DATA_PATH / "metadata.jsonl"
-    start_index = (
+    cautious: bool = False  # ask whether you want to scrape the PDF and whether the metadata guesses are correct
+    start_index: int = (
         int(sys.argv[1]) if len(sys.argv) > 1 else 0
     )  # the row of metadata.jsonl to start ingesting; everything prior to this will be ignored
-    batch_size = 1  # the number of webpages to ingest at a time
+    batch_size: int = 50  # the number of webpages to ingest at a time
 
     # settings relevant to web_search mode
-    query = "Centre for Collective Intelligence Design"
-    site_url = NESTA_SITE_URL
-    subdirectories = sorted(
+    query: str = "Centre for Collective Intelligence Design"
+    site_url: str = NESTA_SITE_URL
+    subdirectories: Optional[List[str]] = sorted(
         ["toolkit", "team", "report", "project", "press-release", "jobs", "feature", "event", "blog"]
     )  # optional
 
-    if mode not in possible_modes:
-        raise Exception(f"""mode must be one of the following:{', '.join([f"'{mode}'" for mode in possible_modes])}""")
+    # settings relevant to give_urls mode
+    given_urls: List[str] = []
+
+    if mode not in mode_type.__args__:
+        raise Exception(
+            f"""mode must be one of the following:{', '.join([f"'{mode}'" for mode in mode_type.__args__])}"""
+        )
 
     if mode == "web_dump":
         # if scraping/ingesting from entire Nesta website data dump
 
-        metadata_df = pd.read_json(metadata_path, lines=True)
+        metadata_df = pd.read_json(METADATA_PATH, lines=True)
         downloaded = metadata_df["_status_code"].apply(lambda val: val == 200)
         metadata_df = metadata_df[downloaded]
         n_rows = metadata_df.shape[0]
@@ -530,7 +570,7 @@ if __name__ == "__main__":
                 webpages_to_ingested_data(df=df, replace=replace)
 
     elif mode == "web_search":
-        # if scraping from web
+        # if scraping from web via a search
 
         if subdirectories:
             urls = [site_url + "/" + subdirectory for subdirectory in subdirectories]
@@ -547,3 +587,8 @@ if __name__ == "__main__":
                 results_returned = search_query_to_ingested_data(query, url, start=start, replace=replace)
                 if not results_returned:
                     break
+
+    elif mode == "given_urls":
+        # if scraping from web via a list of urls
+
+        urls_to_ingested_data(given_urls, replace=replace)

--- a/retrieval/db/schema.py
+++ b/retrieval/db/schema.py
@@ -179,13 +179,15 @@ if __name__ == "__main__":
     db = lancedb.connect(DB_PATH)
 
     # creating tables
-    if False:
-        db.create_table("document", schema=Document)
-        table = db.create_table("chunk", schema=Chunk)
-        table.create_fts_index("text")
+    db.create_table(
+        "document", schema=Document
+    )  # this has been included experimentally and past versions but is not really needed
+    # and could lead to data redundancy. See similar comment in ingest function in retrieval/db/ingest.py
+    chunk_table = db.create_table("chunk", schema=Chunk)
+    chunk_table.create_fts_index("text")  # this allows full text search of chunk text
 
     # adding full text search index retrospectively
-    if True:
+    if False:
         table = db.open_table("chunk")
         table.create_fts_index("text")
 

--- a/retrieval/retrieve.py
+++ b/retrieval/retrieve.py
@@ -6,7 +6,6 @@ import re
 from collections import OrderedDict
 from typing import List
 from typing import Optional
-from typing import TypedDict
 
 import lancedb
 
@@ -20,16 +19,16 @@ from langchain.docstore.document import Document as LangchainDocument
 from langchain_community.vectorstores import LanceDB
 from langchain_core.retrievers import BaseRetriever
 from langchain_openai import OpenAIEmbeddings
+from langgraph.graph import MessagesState
 from openai import AsyncOpenAI
 from openai import OpenAI
 from retrieval.db.schema import Chunk
 from utils import unique
 
 
-class RetrieverInput(TypedDict):
-    """Class for specifying what the retriever input should be; used as a State class with LangGraph"""
+class RetrieverInput(MessagesState):
+    """Class for specifying what the retriever input should be; also used as a State class with LangGraph"""
 
-    input: str
     filter_condition: str
     merge: bool
 
@@ -56,7 +55,7 @@ class CustomRetriever(BaseRetriever):
         """
 
         logger.info(f"Input to retriever: {input}")
-        query = input["input"]
+        query = input["messages"][-1].content
         filter_condition = input.get("filter_condition") or None  # if '' then want None
         merge = input.get("merge")
 

--- a/retrieval/retrieve.py
+++ b/retrieval/retrieve.py
@@ -11,6 +11,7 @@ from typing import TypedDict
 import lancedb
 
 from config import DB_PATH
+from config import DEFAULT_EMBEDDINGS_MODEL
 from dotenv import load_dotenv
 from dsp_nesta_brain import logger
 from lancedb.db import LanceDBConnection
@@ -192,7 +193,7 @@ class CustomRetriever(BaseRetriever):
     async def async_vector(string: str) -> List[float]:
         """Calculate the embedding vector of string"""
         async_client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-        result = await async_client.embeddings.create(model="text-embedding-3-small", input=string)
+        result = await async_client.embeddings.create(model=DEFAULT_EMBEDDINGS_MODEL, input=string)
         vector = result.data[0].embedding
         return vector
 
@@ -200,7 +201,7 @@ class CustomRetriever(BaseRetriever):
     def vector(string: str) -> List[float]:
         """Calculate the embedding vector of string"""
         client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-        vector = client.embeddings.create(model="text-embedding-3-small", input=string).data[0].embedding
+        vector = client.embeddings.create(model=DEFAULT_EMBEDDINGS_MODEL, input=string).data[0].embedding
         return vector
 
 
@@ -239,7 +240,7 @@ if __name__ == "__main__":
         # lancedb's neater syntax for handling embeddings doesn't work because of the way the schema has been specified
 
         query = "HACID project"
-        vector_ = client.embeddings.create(model="text-embedding-3-small", input=query).data[0].embedding
+        vector_ = client.embeddings.create(model=DEFAULT_EMBEDDINGS_MODEL, input=query).data[0].embedding
         # chunk_table.create_fts_index("text")
         # chunk_results = chunk_table.search()
         #                   .where('source.location = "https://www.nesta.org.uk/project/centre-collective-intelligence-design/"')

--- a/scraping/scrape.py
+++ b/scraping/scrape.py
@@ -119,9 +119,9 @@ def scrape(url: str) -> str:
 
         # metadata
         title = soup.find("title").getText().replace(" | Nesta", "")
-        script = soup.find_all("script")[0]  # publication date should be in the first script element of the page
+        data_layer = extract_data_layer(soup)
         try:
-            date_pub = re.search("'publishDate': '(\d{4}-\d{2}-\d{2})'", script.getText()).groups()[0]  # noqa
+            date_pub = data_layer.pop("publishDate")
             date_pub = dt.datetime.strptime(date_pub, "%Y-%m-%d")
         except Exception:
             logger.warning(f"Webpage {url} had no publication date")
@@ -130,7 +130,12 @@ def scrape(url: str) -> str:
     except Exception as e:
         logger.critical(f"The following error was encountered while scraping {url}:\n{e}")
 
-    return {"text": text.strip(), "title": title, "date_pub": date_pub}
+    result = data_layer
+    result["text"] = text.strip()
+    result["title"] = title
+    result["date_pub"] = date_pub
+
+    return result
 
 
 def extract_pdf_links(soup: BeautifulSoup, base: str = "https://www.nesta.org.uk") -> list:

--- a/utils.py
+++ b/utils.py
@@ -3,6 +3,8 @@ from typing import List
 from typing import Tuple
 from typing import Union
 
+from dsp_nesta_brain import logger
+
 
 def first(seq: Union[List, Tuple], lambda_: Callable) -> object:
     """Return first element of seq that returns a positive result from the condition specified in lambda_"""
@@ -24,3 +26,15 @@ def unique(seq: Union[List, Tuple]) -> List:
 def bold(string: str) -> str:
     """Make a string bold"""
     return f"\033[1m{string}\033[0m"
+
+
+def yesno(question: str) -> bool:
+    """Answer a yes/no question and return the answer as a bool"""
+    instructions = " (0/1 or y/n): "
+    question = f"{question} {instructions}"
+    while True:
+        resp = input(question)
+        if resp.lower() in ["0", "1", "y", "n", ""]:
+            return resp.lower() in ["1", "y"]
+        else:
+            logger.info("Invalid binary question input, try again: ")


### PR DESCRIPTION
The langgraph branch tested a simple graph for making retrieval more sophisticated ('retrieval graph').

This branch tests a simple graph for commenting on or extending LLM results ('chat graph'). 

The following changes have been necessary in order to make the code as simple, flexible and comprehensible as possible for future development.
* The State class representing inputs to graph nodes now inherits from LangGraph's MessagesState, which future collaborators will recognise easily from LangGraph documentation and examples
* To enable this, the old Response class representing chain output has become CustomAIMessage, a class which inherits from LangChain's AIMessage
*  Within the graph, responses are now converted into CustomAIMessages and appended to state['messages']

The simple graph has a node which comments on whether the LLM response is likely to be using up-to-date information, based on context metadata.

I think future deployments need to avoid this split between retrieval and chat graphs and just have one graph representing the entire workflow.